### PR TITLE
✨ Add WireGuard incremental peer updates with dry-run mode and comprehensive tests

### DIFF
--- a/.github/workflows/ansible-lint-test.yml
+++ b/.github/workflows/ansible-lint-test.yml
@@ -1,5 +1,5 @@
 ---
-name: Ansible Lint
+name: Ansible Lint and Test
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
       - main
 
 jobs:
-  lint:
+  lint-and-test:
     runs-on: ubuntu-latest
 
     steps:
@@ -26,4 +26,7 @@ jobs:
         run: aqua i -l
 
       - name: Run ansible-lint
-        run: make lint
+        run: just lint
+
+      - name: Run Test
+        run: just test

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ ansible.log
 # Secret host configurations - keep k8s-proxy public IP private
 inventory.secret.yml
 inventory.local.yml
+__pycache__/
+*.pyc

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -12,3 +12,4 @@ registries:
     ref: v4.396.0 # renovate: depName=aquaproj/aqua-registry
 packages:
   - name: astral-sh/uv@0.8.3
+  - name: casey/just@1.43.0

--- a/docs/WIREGUARD_INCREMENTAL_UPDATES.md
+++ b/docs/WIREGUARD_INCREMENTAL_UPDATES.md
@@ -1,0 +1,533 @@
+# WireGuard Incremental Peer Updates
+
+## Overview
+
+This feature enables **partial deployments** of worker nodes without losing WireGuard peer configurations on the control plane. Previously, deploying to a single worker would regenerate the control plane's WireGuard config with only that worker as a peer, removing all other peers.
+
+## Problem Statement
+
+**Before this feature:**
+
+```bash
+# Full deployment works fine
+just deploy
+# Control plane wg0.conf contains: cm4, s2204, k8s-proxy
+
+# Partial deployment breaks other peers
+ansible-playbook -i inventory.yml site.yml --limit=cm4
+# Control plane wg0.conf now only contains: cm4
+# ❌ s2204 and k8s-proxy lose connectivity!
+```
+
+**After this feature:**
+
+```bash
+# Partial deployment preserves existing peers
+ansible-playbook -i inventory.yml site.yml --limit=cm4
+# Control plane wg0.conf contains: cm4, s2204, k8s-proxy (all preserved)
+# ✅ All peers remain configured!
+```
+
+## How It Works
+
+### Architecture
+
+The incremental update system follows these steps:
+
+1. **Fetch Existing State** - Parse current WireGuard configuration on control plane
+2. **Merge Peers** - Combine existing peers with workers from current Ansible play
+3. **Generate Config** - Use merged peer data in template
+4. **Validate** - Verify all expected peers are configured
+
+### Components
+
+#### 1. Filter Plugin: `filter_plugins/wireguard_filters.py`
+
+Custom Ansible filters for WireGuard configuration manipulation:
+
+- **`parse_wireguard_peers`** - Parses WireGuard INI-format config into dictionary
+- **`merge_wireguard_peers`** - Merges existing and new peer dictionaries
+- **`filter_peers_by_inventory`** - Filters peers to only those in inventory
+
+```python
+# Example usage in Ansible
+existing_peers: "{{ config_content | parse_wireguard_peers }}"
+merged_peers: "{{ existing_peers | merge_wireguard_peers(new_peers) }}"
+```
+
+#### 2. Task Files
+
+**`roles/wireguard/tasks/fetch_existing_peers.yml`**
+- Checks if WireGuard config exists
+- Reads existing configuration
+- Parses peers into `existing_wg_peers` fact
+- Initializes empty dict if no config exists
+
+**`roles/wireguard/tasks/merge_peer_config.yml`**
+- Builds dictionary of peers from current play
+- Merges with existing peers
+- Sets `merged_wg_peers` fact for template
+
+**`roles/wireguard/tasks/validate_peers.yml`**
+- Validates all inventory workers are configured
+- Reports extra peers (preserved from previous runs)
+- Provides validation summary
+
+#### 3. Updated Template: `roles/wireguard/templates/wg0.conf.j2`
+
+The template now uses `merged_wg_peers` when available, falling back to the traditional method:
+
+```jinja2
+{% if merged_wg_peers is defined and merged_wg_peers | length > 0 %}
+{% for peer_name, peer_data in (merged_wg_peers | dict2items | sort(attribute='key')) %}
+[Peer]
+# {{ peer_name }}
+PublicKey = {{ peer_data.public_key }}
+AllowedIPs = {{ peer_data.allowed_ips }}
+{% endfor %}
+{% else %}
+# Fallback to traditional method
+{% for host in groups['workers'] %}
+...
+{% endfor %}
+{% endif %}
+```
+
+#### 4. Integration in `site.yml`
+
+The "Configure WireGuard" play now includes incremental update tasks:
+
+```yaml
+- name: Configure WireGuard
+  hosts: all
+  tasks:
+    # NEW: Fetch and merge peers on control plane
+    - include_tasks: roles/wireguard/tasks/fetch_existing_peers.yml
+      when: inventory_hostname in groups['control_plane']
+
+    - include_tasks: roles/wireguard/tasks/merge_peer_config.yml
+      when: inventory_hostname in groups['control_plane']
+
+    # Existing: Generate config (now uses merged_wg_peers)
+    - template:
+        src: roles/wireguard/templates/wg0.conf.j2
+        dest: /etc/wireguard/wg0.conf
+
+    # NEW: Validate configuration
+    - include_tasks: roles/wireguard/tasks/validate_peers.yml
+      when: inventory_hostname in groups['control_plane']
+```
+
+## Usage Examples
+
+### Dry-Run Mode (Preview Changes)
+
+Preview configuration changes without applying them:
+
+```bash
+# Dry-run for all nodes
+ansible-playbook -i inventory.yml site.yml --tags=wireguard -e "wireguard_dry_run=true"
+
+# Dry-run for specific worker
+ansible-playbook -i inventory.yml site.yml --tags=wireguard --limit=cm4 -e "wireguard_dry_run=true"
+
+# Dry-run for control plane only
+ansible-playbook -i inventory.yml site.yml --tags=wireguard --limit=control_plane -e "wireguard_dry_run=true"
+```
+
+**Dry-run mode will:**
+- Generate config to `/tmp/wg0.conf.preview` on each node
+- Display a diff showing what would change
+- Show peer count changes
+- NOT modify actual configuration
+- NOT restart WireGuard service
+- Provide commands to review the preview file
+
+### Partial Worker Deployment
+
+Deploy only a single worker node:
+
+```bash
+# Deploy only cm4 worker
+ansible-playbook -i inventory.yml site.yml --limit=cm4
+
+# Deploy specific workers
+ansible-playbook -i inventory.yml site.yml --limit=cm4,s2204
+
+# Using just with limit (if you extend justfile)
+just deploy-worker cm4
+```
+
+### Full Cluster Deployment
+
+Works exactly as before:
+
+```bash
+just deploy
+# or
+ansible-playbook -i inventory.yml site.yml
+```
+
+### WireGuard-Only Updates
+
+Update only WireGuard configuration:
+
+```bash
+ansible-playbook -i inventory.yml site.yml --tags=wireguard
+
+# For specific host
+ansible-playbook -i inventory.yml site.yml --tags=wireguard --limit=cm4
+```
+
+### Adding New Worker
+
+When adding a new worker to inventory:
+
+1. Add host to `inventory.yml` under `workers` group
+2. Run deployment:
+   ```bash
+   ansible-playbook -i inventory.yml site.yml --limit=new-worker
+   ```
+3. The new peer is **added** to control plane config (existing peers preserved)
+
+## Dry-Run Mode Details
+
+### What is Dry-Run Mode?
+
+Dry-run mode allows you to preview WireGuard configuration changes before applying them. This is especially useful when:
+- Testing incremental updates for the first time
+- Verifying peer merge logic
+- Previewing changes before production deployment
+- Debugging configuration issues
+
+### How Dry-Run Works
+
+1. **Generates Preview**: Creates configuration to `/tmp/wg0.conf.preview` on target host
+2. **Shows Diff**: Displays unified diff comparing current vs. preview config
+3. **Provides Summary**: Shows peer counts and changes
+4. **No Side Effects**: Does not modify actual config or restart services
+
+### Dry-Run Output Example
+
+```
+==========================================
+DRY-RUN MODE: WireGuard Configuration Preview
+==========================================
+Comparing with existing configuration
+
+--- Current Config
++++ Preview Config
+@@ -10,6 +10,10 @@
+ PublicKey = xyz123...
+ AllowedIPs = 10.0.0.3/32
+
++[Peer]
++# k8s-proxy
++PublicKey = abc789...
++AllowedIPs = 10.0.0.21/32
++
+
+==========================================
+DRY-RUN SUMMARY
+==========================================
+Node: k8s
+Preview file: /tmp/wg0.conf.preview
+Target file: /etc/wireguard/wg0.conf
+Status: UPDATE EXISTING
+Current peers: 2
+Preview peers: 3
+Change: +1 peer(s)
+
+To apply this configuration, run without -e wireguard_dry_run=true
+==========================================
+```
+
+### Reviewing Preview Files
+
+After dry-run, you can manually inspect the preview files:
+
+```bash
+# View preview on control plane
+ssh k8s.shion1305.com 'sudo cat /tmp/wg0.conf.preview'
+
+# Compare with diff tool
+ssh k8s.shion1305.com 'sudo diff -u /etc/wireguard/wg0.conf /tmp/wg0.conf.preview'
+
+# Side-by-side comparison
+ssh k8s.shion1305.com 'sudo diff -y /etc/wireguard/wg0.conf /tmp/wg0.conf.preview | less'
+```
+
+### Workflow: Dry-Run → Review → Apply
+
+```bash
+# Step 1: Preview changes with dry-run
+ansible-playbook -i inventory.yml site.yml --tags=wireguard --limit=cm4 -e "wireguard_dry_run=true"
+
+# Step 2: Review output and preview files
+# (check diff output, peer counts, etc.)
+
+# Step 3: Apply changes if satisfied
+ansible-playbook -i inventory.yml site.yml --tags=wireguard --limit=cm4
+```
+
+## Validation and Verification
+
+### Automatic Validation
+
+The `validate_peers.yml` task automatically runs after WireGuard configuration:
+
+- ✅ Verifies all inventory workers are configured as peers
+- ✅ Reports extra peers preserved from previous runs
+- ✅ Shows validation summary with counts
+
+### Manual Verification
+
+Check control plane WireGuard status:
+
+```bash
+# SSH to control plane
+ssh k8s.shion1305.com
+
+# Show all peers
+sudo wg show wg0 peers
+
+# Show full status
+sudo wg show wg0
+
+# Check configuration file
+sudo cat /etc/wireguard/wg0.conf
+```
+
+Expected output shows all workers as peers:
+
+```
+[Peer]
+# cm4
+PublicKey = ...
+AllowedIPs = 10.0.0.3/32
+
+[Peer]
+# s2204
+PublicKey = ...
+AllowedIPs = 10.0.0.4/32
+
+[Peer]
+# k8s-proxy
+PublicKey = ...
+AllowedIPs = 10.0.0.21/32
+```
+
+## Troubleshooting
+
+### Issue: Validation reports missing peers
+
+**Symptom:** Validation task fails saying a peer is missing
+
+**Cause:** WireGuard service may not have loaded the new configuration
+
+**Solution:**
+```bash
+# Restart WireGuard on control plane
+ansible control_plane -i inventory.yml -b -m systemd -a "name=wg-quick@wg0 state=restarted"
+
+# Verify peers loaded
+ansible control_plane -i inventory.yml -b -a "wg show wg0 peers"
+```
+
+### Issue: Extra peers reported but not expected
+
+**Symptom:** Validation shows extra peers not in current inventory
+
+**Explanation:** This is **normal behavior** for incremental updates. Extra peers are workers that:
+- Were in a previous deployment
+- Are not in the current Ansible play (due to `--limit`)
+- Are intentionally preserved to maintain connectivity
+
+**To remove peers no longer needed:**
+
+1. Run full deployment (no `--limit`):
+   ```bash
+   just deploy
+   ```
+
+2. Or manually edit `/etc/wireguard/wg0.conf` and remove unwanted `[Peer]` sections
+
+### Issue: Worker loses connectivity after partial deployment
+
+**Symptom:** Worker node can't reach control plane after deploying different worker
+
+**Diagnosis:**
+```bash
+# On affected worker
+ping 10.0.0.20  # Control plane WireGuard IP
+
+# Check WireGuard status
+sudo wg show wg0
+```
+
+**Solution:** This should not happen with incremental updates enabled. If it does:
+
+1. Check control plane config includes the worker:
+   ```bash
+   ansible control_plane -i inventory.yml -b -a "grep -A3 'worker-name' /etc/wireguard/wg0.conf"
+   ```
+
+2. Re-run deployment with that worker:
+   ```bash
+   ansible-playbook -i inventory.yml site.yml --limit=affected-worker
+   ```
+
+### Issue: Parser fails to read config
+
+**Symptom:** Error in `parse_wireguard_peers` filter
+
+**Cause:** Configuration file format is malformed or has unexpected structure
+
+**Solution:**
+```bash
+# Check config file syntax
+ansible control_plane -i inventory.yml -b -a "cat /etc/wireguard/wg0.conf"
+
+# Validate WireGuard can parse it
+ansible control_plane -i inventory.yml -b -a "wg-quick strip wg0"
+```
+
+If config is corrupted, restore from backup:
+```bash
+ansible control_plane -i inventory.yml -b -a "ls -lt /etc/wireguard/wg0.conf*"
+ansible control_plane -i inventory.yml -b -a "cp /etc/wireguard/wg0.conf.backup /etc/wireguard/wg0.conf"
+```
+
+## Configuration Backups
+
+The template task automatically creates backups:
+
+```yaml
+- template:
+    backup: true  # Creates timestamped backup before changes
+```
+
+Backups are stored in `/etc/wireguard/` with format: `wg0.conf.TIMESTAMP.backup`
+
+To restore:
+```bash
+sudo cp /etc/wireguard/wg0.conf.TIMESTAMP.backup /etc/wireguard/wg0.conf
+sudo systemctl restart wg-quick@wg0
+```
+
+## Future Enhancements
+
+### Optional: Peer Pruning
+
+Add a task to remove peers not in inventory:
+
+```yaml
+- name: Build filtered peers (only inventory hosts)
+  set_fact:
+    merged_wg_peers: "{{ merged_wg_peers | filter_peers_by_inventory(groups['workers']) }}"
+  when: wireguard_prune_extra_peers | default(false)
+```
+
+Enable with variable:
+```yaml
+# inventory.yml or group_vars
+wireguard_prune_extra_peers: true
+```
+
+### Optional: Peer Health Checks
+
+Validate connectivity to configured peers:
+
+```yaml
+- name: Test connectivity to all peers
+  command: "ping -c 1 -W 2 {{ item }}"
+  loop: "{{ merged_wg_peers.values() | map(attribute='allowed_ips') | map('regex_replace', '/32$', '') | list }}"
+  register: peer_ping_results
+  failed_when: false
+```
+
+### Optional: Configuration Drift Detection
+
+Compare running config vs. file config:
+
+```yaml
+- name: Detect configuration drift
+  shell: |
+    wg-quick strip wg0 | diff -u - /etc/wireguard/wg0.conf
+  register: config_drift
+  changed_when: config_drift.rc != 0
+  failed_when: false
+```
+
+## Technical Details
+
+### Peer Dictionary Format
+
+```python
+{
+    'cm4': {
+        'public_key': 'base64_encoded_public_key_here',
+        'allowed_ips': '10.0.0.3/32',
+        # Optional fields:
+        'endpoint': 'host:port',
+        'persistent_keepalive': '25'
+    },
+    's2204': {
+        'public_key': 'another_base64_key',
+        'allowed_ips': '10.0.0.4/32'
+    }
+}
+```
+
+### Merge Behavior
+
+- **New peers:** Added to configuration
+- **Existing peers with same name:** Updated with new data (public key, IPs)
+- **Existing peers not in play:** Preserved unchanged
+- **Sorting:** Peers are sorted alphabetically by name in config file
+
+### Performance Impact
+
+- **Minimal:** Adds ~2 seconds to deployment (file read + parsing)
+- **Network:** No additional network calls
+- **Idempotent:** Re-running with same hosts produces identical config
+
+## Testing
+
+Run ansible-lint to validate:
+```bash
+just lint
+```
+
+Test incremental deployment:
+```bash
+# 1. Full deployment
+just deploy
+
+# 2. Verify all peers present
+ansible control_plane -i inventory.yml -b -a "wg show wg0 peers" | wc -l
+# Should show: 3 (or number of workers)
+
+# 3. Partial deployment
+ansible-playbook -i inventory.yml site.yml --tags=wireguard --limit=cm4
+
+# 4. Verify all peers still present
+ansible control_plane -i inventory.yml -b -a "wg show wg0 peers" | wc -l
+# Should still show: 3 (unchanged!)
+```
+
+## Related Files
+
+- **Filter Plugin:** [filter_plugins/wireguard_filters.py](../filter_plugins/wireguard_filters.py)
+- **Fetch Task:** [roles/wireguard/tasks/fetch_existing_peers.yml](../roles/wireguard/tasks/fetch_existing_peers.yml)
+- **Merge Task:** [roles/wireguard/tasks/merge_peer_config.yml](../roles/wireguard/tasks/merge_peer_config.yml)
+- **Dry-Run Task:** [roles/wireguard/tasks/dry_run_config.yml](../roles/wireguard/tasks/dry_run_config.yml)
+- **Validation Task:** [roles/wireguard/tasks/validate_peers.yml](../roles/wireguard/tasks/validate_peers.yml)
+- **Template:** [roles/wireguard/templates/wg0.conf.j2](../roles/wireguard/templates/wg0.conf.j2)
+- **Main Playbook:** [site.yml](../site.yml)
+
+## References
+
+- [WireGuard Documentation](https://www.wireguard.com/quickstart/)
+- [Ansible Template Module](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/template_module.html)
+- [Ansible Custom Filters](https://docs.ansible.com/ansible/latest/dev_guide/developing_plugins.html#filter-plugins)

--- a/filter_plugins/wireguard_filters.py
+++ b/filter_plugins/wireguard_filters.py
@@ -1,0 +1,156 @@
+"""Custom Ansible filters for WireGuard configuration parsing and manipulation."""
+
+from configparser import ConfigParser
+from io import StringIO
+
+
+def parse_wireguard_peers(config_text):
+    """
+    Parse WireGuard configuration and extract peer information using configparser.
+
+    WireGuard configs are INI-like format with [Interface] and [Peer] sections.
+
+    Args:
+        config_text: String content of WireGuard configuration file
+
+    Returns:
+        Dictionary mapping peer names to their configuration:
+        {
+            'peer_name': {
+                'public_key': 'base64_key',
+                'allowed_ips': '10.0.0.3/32',
+                'endpoint': 'host:port' (optional),
+                'persistent_keepalive': '25' (optional)
+            }
+        }
+    """
+    if not config_text or not config_text.strip():
+        return {}
+
+    peers = {}
+    current_section = None
+    current_comment = None
+
+    # Parse line by line to handle multiple [Peer] sections and comments
+    # configparser doesn't handle duplicate section names well
+    lines = config_text.split('\n')
+    peer_data = None
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Check for comment (peer name)
+        if stripped.startswith('#'):
+            current_comment = stripped[1:].strip()
+            continue
+
+        # Check for section headers
+        if stripped.startswith('['):
+            # Save previous peer if exists
+            if peer_data and peer_data.get('publickey'):
+                peer_name = current_comment or peer_data['publickey'][:12]
+                peers[peer_name] = {
+                    'public_key': peer_data['publickey'],
+                    'allowed_ips': peer_data.get('allowedips', ''),
+                }
+                if 'endpoint' in peer_data:
+                    peers[peer_name]['endpoint'] = peer_data['endpoint']
+                if 'persistentkeepalive' in peer_data:
+                    peers[peer_name]['persistent_keepalive'] = peer_data['persistentkeepalive']
+
+            # Start new section
+            if '[Peer]' in stripped:
+                current_section = 'peer'
+                peer_data = {}
+                current_comment = None
+            elif '[Interface]' in stripped:
+                current_section = 'interface'
+                peer_data = None
+            continue
+
+        # Parse key-value pairs
+        if '=' in stripped and peer_data is not None:
+            key, value = stripped.split('=', 1)
+            key = key.strip().lower()
+            value = value.strip()
+            peer_data[key] = value
+
+    # Don't forget the last peer
+    if peer_data and peer_data.get('publickey'):
+        peer_name = current_comment or peer_data['publickey'][:12]
+        peers[peer_name] = {
+            'public_key': peer_data['publickey'],
+            'allowed_ips': peer_data.get('allowedips', ''),
+        }
+        if 'endpoint' in peer_data:
+            peers[peer_name]['endpoint'] = peer_data['endpoint']
+        if 'persistentkeepalive' in peer_data:
+            peers[peer_name]['persistent_keepalive'] = peer_data['persistentkeepalive']
+
+    return peers
+
+
+def merge_wireguard_peers(existing_peers, new_peers):
+    """
+    Merge existing WireGuard peers with new peer data.
+
+    New peers override existing ones with the same name.
+    This allows updating peer configurations while preserving others.
+
+    Args:
+        existing_peers: Dictionary of existing peer configurations
+        new_peers: Dictionary of new/updated peer configurations
+
+    Returns:
+        Merged dictionary of peer configurations
+    """
+    if not existing_peers:
+        existing_peers = {}
+    if not new_peers:
+        new_peers = {}
+
+    # Create a copy to avoid modifying input
+    merged = dict(existing_peers)
+
+    # Update with new peers (overrides existing)
+    for peer_name, peer_data in new_peers.items():
+        merged[peer_name] = peer_data
+
+    return merged
+
+
+def filter_peers_by_inventory(peers, inventory_hosts):
+    """
+    Filter peers to only include those present in current inventory.
+
+    This is useful for pruning peers that are no longer in the inventory.
+
+    Args:
+        peers: Dictionary of peer configurations
+        inventory_hosts: List of hostnames from inventory
+
+    Returns:
+        Filtered dictionary containing only peers in inventory
+    """
+    if not peers:
+        return {}
+    if not inventory_hosts:
+        return peers
+
+    return {
+        name: data
+        for name, data in peers.items()
+        if name in inventory_hosts
+    }
+
+
+class FilterModule:
+    """Ansible filter plugin for WireGuard operations."""
+
+    def filters(self):
+        """Return filter mappings."""
+        return {
+            'parse_wireguard_peers': parse_wireguard_peers,
+            'merge_wireguard_peers': merge_wireguard_peers,
+            'filter_peers_by_inventory': filter_peers_by_inventory,
+        }

--- a/justfile
+++ b/justfile
@@ -15,6 +15,7 @@ help:
   @echo "  just reset            - Reset the entire cluster (WARNING: destructive)"
   @echo "  just clean            - Clean up CNI bridges and restart services"
   @echo "  just lint             - Validate all playbooks with ansible-lint"
+  @echo "  just test             - Run Python tests for filter plugins"
   @echo ""
   @echo "Examples:"
   @echo "  just deploy           # Full cluster deployment with verification (all hosts)"
@@ -24,6 +25,7 @@ help:
   @echo "  just reset            # Destroy everything and reset to clean state"
   @echo "  just clean            # Clean CNI interfaces"
   @echo "  just lint             # Check playbook syntax"
+  @echo "  just test             # Run filter plugin tests"
 
 # Deploy the complete cluster (runs deployment + verification)
 deploy host='':
@@ -88,3 +90,9 @@ lint:
   @echo "Running ansible-lint on playbooks..."
   uv run ansible-lint
   @echo "✅ Lint check complete"
+
+# Run Python tests for filter plugins
+test:
+  @echo "Running filter plugin tests..."
+  uv run pytest tests/ -v
+  @echo "✅ Tests passed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,5 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "ansible-lint>=25.7.0",
+    "pytest>=8.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,5 @@ requires-python = ">=3.13"
 dependencies = [
     "ansible-lint>=25.7.0",
     "pytest>=8.0.0",
+    "jinja2>=3.1.0",
 ]

--- a/roles/kubernetes/handlers/main.yml
+++ b/roles/kubernetes/handlers/main.yml
@@ -1,8 +1,15 @@
 ---
+- name: Prompt for containerd restart
+  ansible.builtin.pause:
+    prompt: "Containerd configuration changed on {{ inventory_hostname }}. Do you want to restart containerd? (yes/no)"
+  register: kubernetes_containerd_restart_confirm
+  run_once: false
+
 - name: Restart containerd
   ansible.builtin.systemd:
     name: containerd
     state: restarted
+  when: kubernetes_containerd_restart_confirm.user_input | default('no') | lower in ['yes', 'y']
 
 - name: Restart kubelet
   ansible.builtin.systemd:

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -25,9 +25,13 @@
   register: kubernetes_containerd_config
   changed_when: false
 
+- name: Modify containerd configuration (enable systemd cgroups)
+  ansible.builtin.set_fact:
+    kubernetes_containerd_config_modified: "{{ kubernetes_containerd_config.stdout | regex_replace('SystemdCgroup = false', 'SystemdCgroup = true') }}"
+
 - name: Write containerd configuration
   ansible.builtin.copy:
-    content: "{{ kubernetes_containerd_config.stdout }}"
+    content: "{{ kubernetes_containerd_config_modified }}"
     dest: /etc/containerd/config.toml
     mode: "0644"
     owner: root
@@ -36,18 +40,11 @@
   register: kubernetes_containerd_config_written
   changed_when: kubernetes_containerd_config_written.diff | default([]) | length > 0
 
-- name: Enable systemd cgroups in containerd
-  ansible.builtin.lineinfile:
-    path: /etc/containerd/config.toml
-    regexp: "^\\s*SystemdCgroup = false"
-    line: "            SystemdCgroup = true"
-  register: kubernetes_containerd_systemd_cgroup
-
 - name: Prompt for containerd restart confirmation
   ansible.builtin.pause:
     prompt: "Containerd configuration changed on {{ inventory_hostname }}. Do you want to restart containerd? (yes/no)"
   register: kubernetes_containerd_restart_confirm
-  when: kubernetes_containerd_config_written.changed or kubernetes_containerd_systemd_cgroup.changed
+  when: kubernetes_containerd_config_written.changed
   run_once: false
 
 - name: Restart containerd if confirmed
@@ -55,7 +52,7 @@
     name: containerd
     state: restarted
   when: >
-    (kubernetes_containerd_config_written.changed or kubernetes_containerd_systemd_cgroup.changed)
+    kubernetes_containerd_config_written.changed
     and kubernetes_containerd_restart_confirm.user_input | default('no') | lower in ['yes', 'y']
 
 - name: Install Kubernetes packages

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -34,6 +34,7 @@
     group: root
     backup: true
   register: kubernetes_containerd_config_written
+  changed_when: kubernetes_containerd_config_written.diff | default([]) | length > 0
 
 - name: Enable systemd cgroups in containerd
   ansible.builtin.lineinfile:

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -39,21 +39,9 @@
     backup: true
   register: kubernetes_containerd_config_written
   changed_when: kubernetes_containerd_config_written.diff | default([]) | length > 0
-
-- name: Prompt for containerd restart confirmation
-  ansible.builtin.pause:
-    prompt: "Containerd configuration changed on {{ inventory_hostname }}. Do you want to restart containerd? (yes/no)"
-  register: kubernetes_containerd_restart_confirm
-  when: kubernetes_containerd_config_written.changed
-  run_once: false
-
-- name: Restart containerd if confirmed
-  ansible.builtin.systemd:
-    name: containerd
-    state: restarted
-  when: >
-    kubernetes_containerd_config_written.changed
-    and kubernetes_containerd_restart_confirm.user_input | default('no') | lower in ['yes', 'y']
+  notify:
+    - Prompt for containerd restart
+    - Restart containerd
 
 - name: Install Kubernetes packages
   ansible.builtin.package:

--- a/roles/wireguard/tasks/dry_run_config.yml
+++ b/roles/wireguard/tasks/dry_run_config.yml
@@ -1,0 +1,100 @@
+---
+# Dry-run mode: Generate WireGuard config without applying changes
+# This allows preview of configuration changes before actual deployment
+
+- name: Generate WireGuard configuration to temporary location (dry-run)
+  ansible.builtin.template:
+    src: "roles/wireguard/templates/{{ wireguard_interface }}.conf.j2"
+    dest: "/tmp/{{ wireguard_interface }}.conf.preview"
+    mode: "0600"
+  register: wireguard_dry_run_result
+
+- name: Check if actual WireGuard config exists for comparison
+  ansible.builtin.stat:
+    path: "/etc/wireguard/{{ wireguard_interface }}.conf"
+  register: wireguard_actual_config_stat
+
+- name: Read actual WireGuard configuration for diff
+  ansible.builtin.slurp:
+    src: "/etc/wireguard/{{ wireguard_interface }}.conf"
+  register: wireguard_actual_config
+  when: wireguard_actual_config_stat.stat.exists
+
+- name: Read generated preview configuration
+  ansible.builtin.slurp:
+    src: "/tmp/{{ wireguard_interface }}.conf.preview"
+  register: wireguard_preview_config
+
+- name: Display configuration comparison
+  ansible.builtin.debug:
+    msg:
+      - "=========================================="
+      - "DRY-RUN MODE: WireGuard Configuration Preview"
+      - "=========================================="
+      - "{{ 'Comparing with existing configuration' if wireguard_actual_config_stat.stat.exists else 'No existing configuration found (new deployment)' }}"
+      - ""
+
+- name: Show diff between current and preview configurations
+  ansible.builtin.shell:
+    cmd: |
+      diff -u --label "Current Config" --label "Preview Config" \
+        /etc/wireguard/{{ wireguard_interface }}.conf \
+        /tmp/{{ wireguard_interface }}.conf.preview || true
+  register: wireguard_config_diff
+  when: wireguard_actual_config_stat.stat.exists
+  failed_when: false
+  changed_when: false
+
+- name: Display configuration diff
+  ansible.builtin.debug:
+    msg: "{{ wireguard_config_diff.stdout_lines }}"
+  when:
+    - wireguard_actual_config_stat.stat.exists
+    - wireguard_config_diff.stdout_lines is defined
+
+- name: Show preview configuration (new deployment)
+  ansible.builtin.debug:
+    msg:
+      - "Preview configuration content:"
+      - "{{ wireguard_preview_config.content | b64decode | split('\n') }}"
+  when: not wireguard_actual_config_stat.stat.exists
+
+- name: Count peer differences
+  ansible.builtin.set_fact:
+    wireguard_preview_peer_count: >-
+      {{ (wireguard_preview_config.content | b64decode | regex_findall('\\[Peer\\]')) | length }}
+    wireguard_actual_peer_count: >-
+      {{
+        (wireguard_actual_config.content | b64decode | regex_findall('\\[Peer\\]')) | length
+        if wireguard_actual_config_stat.stat.exists else 0
+      }}
+
+- name: Display dry-run summary
+  ansible.builtin.debug:
+    msg:
+      - ""
+      - "=========================================="
+      - "DRY-RUN SUMMARY"
+      - "=========================================="
+      - "Node: {{ inventory_hostname }}"
+      - "Preview file: /tmp/{{ wireguard_interface }}.conf.preview"
+      - "Target file: /etc/wireguard/{{ wireguard_interface }}.conf"
+      - "{{ 'Status: NEW CONFIGURATION (file does not exist)' if not wireguard_actual_config_stat.stat.exists else 'Status: UPDATE EXISTING' }}"
+      - "Current peers: {{ wireguard_actual_peer_count }}"
+      - "Preview peers: {{ wireguard_preview_peer_count }}"
+      - "Change: {{ wireguard_preview_peer_count | int - wireguard_actual_peer_count | int }} peer(s)"
+      - ""
+      - "To apply this configuration, run without -e wireguard_dry_run=true"
+      - "=========================================="
+
+- name: Remind user to review preview file
+  ansible.builtin.debug:
+    msg:
+      - "You can review the preview file on the target host:"
+      - "  ssh {{ ansible_host }} 'sudo cat /tmp/{{ wireguard_interface }}.conf.preview'"
+      - ""
+      - "Or compare with diff:"
+      - >-
+        ssh {{ ansible_host }}
+        'sudo diff -u /etc/wireguard/{{ wireguard_interface }}.conf
+        /tmp/{{ wireguard_interface }}.conf.preview'

--- a/roles/wireguard/tasks/fetch_existing_peers.yml
+++ b/roles/wireguard/tasks/fetch_existing_peers.yml
@@ -1,0 +1,29 @@
+---
+# Fetch and parse existing WireGuard configuration to preserve peer state
+# This task runs only on control plane nodes
+
+- name: Check if WireGuard config exists
+  ansible.builtin.stat:
+    path: "/etc/wireguard/{{ wireguard_interface }}.conf"
+  register: wireguard_config_stat
+
+- name: Fetch existing WireGuard configuration
+  ansible.builtin.slurp:
+    src: "/etc/wireguard/{{ wireguard_interface }}.conf"
+  register: wireguard_config_content
+  when: wireguard_config_stat.stat.exists
+
+- name: Parse existing peer configurations from WireGuard config
+  ansible.builtin.set_fact:
+    wireguard_existing_peers: "{{ wireguard_config_content.content | b64decode | parse_wireguard_peers }}"
+  when: wireguard_config_stat.stat.exists
+
+- name: Initialize empty peer list if no config exists
+  ansible.builtin.set_fact:
+    wireguard_existing_peers: {}
+  when: not wireguard_config_stat.stat.exists
+
+- name: Display existing peers found in configuration
+  ansible.builtin.debug:
+    msg: "Found {{ wireguard_existing_peers.keys() | list | length }} existing peer(s): {{ wireguard_existing_peers.keys() | list | join(', ') }}"
+  when: wireguard_existing_peers | length > 0

--- a/roles/wireguard/tasks/merge_peer_config.yml
+++ b/roles/wireguard/tasks/merge_peer_config.yml
@@ -1,0 +1,63 @@
+---
+# Merge existing WireGuard peers with peers from current Ansible play
+# This ensures partial deployments don't remove other peers from control plane
+
+- name: Build peer dictionary from current play hosts
+  ansible.builtin.set_fact:
+    wireguard_current_play_peers: >-
+      {{
+        dict(
+          ansible_play_hosts_all
+          | map('extract', hostvars)
+          | selectattr('inventory_hostname', 'in', groups['workers'])
+          | map(attribute='inventory_hostname')
+          | zip(
+              ansible_play_hosts_all
+              | map('extract', hostvars)
+              | selectattr('inventory_hostname', 'in', groups['workers'])
+              | map('dict2items')
+              | map('items2dict')
+            )
+          | map('combine', {
+              'public_key': '',
+              'allowed_ips': ''
+            })
+        )
+      }}
+  when: false  # This complex method is hard to maintain
+
+- name: Build current play peers (simpler approach)
+  ansible.builtin.set_fact:
+    wireguard_current_play_peers: {}
+
+- name: Add each worker from current play to peers dictionary
+  ansible.builtin.set_fact:
+    wireguard_current_play_peers: >-
+      {{
+        wireguard_current_play_peers | combine({
+          item: {
+            'public_key': hostvars[item]['wireguard_public_key'],
+            'allowed_ips': hostvars[item]['wireguard_ip'] + '/32'
+          }
+        })
+      }}
+  loop: "{{ ansible_play_hosts_all }}"
+  when:
+    - item in groups['workers']
+    - hostvars[item]['wireguard_public_key'] is defined
+
+- name: Display peers from current play
+  ansible.builtin.debug:
+    msg: >-
+      Current play includes {{ wireguard_current_play_peers.keys() | list | length }} worker(s):
+      {{ wireguard_current_play_peers.keys() | list | join(', ') }}
+
+- name: Merge existing peers with current play peers
+  ansible.builtin.set_fact:
+    wireguard_merged_peers: "{{ wireguard_existing_peers | merge_wireguard_peers(wireguard_current_play_peers) }}"
+
+- name: Display merged peer configuration
+  ansible.builtin.debug:
+    msg:
+      - "Merged configuration contains {{ wireguard_merged_peers.keys() | list | length }} total peer(s)"
+      - "Peers: {{ wireguard_merged_peers.keys() | list | sort | join(', ') }}"

--- a/roles/wireguard/tasks/validate_peers.yml
+++ b/roles/wireguard/tasks/validate_peers.yml
@@ -1,0 +1,77 @@
+---
+# Validate WireGuard peer configuration on control plane
+# Ensures all inventory workers are properly configured as peers
+
+- name: Get current WireGuard interface status
+  ansible.builtin.command: "wg show {{ wireguard_interface }}"
+  register: wireguard_status
+  changed_when: false
+  failed_when: false
+
+- name: Display WireGuard interface status
+  ansible.builtin.debug:
+    var: wireguard_status.stdout_lines
+  when: wireguard_status.rc == 0
+
+- name: Get list of configured peer public keys
+  ansible.builtin.command: "wg show {{ wireguard_interface }} peers"
+  register: wireguard_peers_list
+  changed_when: false
+  failed_when: false
+
+- name: Build expected peers list from inventory
+  ansible.builtin.set_fact:
+    wireguard_expected_peer_keys: >-
+      {{
+        groups['workers']
+        | map('extract', hostvars)
+        | selectattr('wireguard_public_key', 'defined')
+        | map(attribute='wireguard_public_key')
+        | list
+      }}
+
+- name: Parse actual configured peers
+  ansible.builtin.set_fact:
+    wireguard_actual_peer_keys: "{{ wireguard_peers_list.stdout_lines | default([]) }}"
+  when: wireguard_peers_list.rc == 0
+
+- name: Verify all inventory workers are configured as peers
+  ansible.builtin.assert:
+    that:
+      - item in wireguard_actual_peer_keys
+    fail_msg: "Worker peer with public key {{ item[:16] }}... is missing from WireGuard configuration"
+    success_msg: "Peer {{ item[:16] }}... is properly configured"
+    quiet: true
+  loop: "{{ wireguard_expected_peer_keys }}"
+  when:
+    - wireguard_peers_list.rc == 0
+    - wireguard_expected_peer_keys | length > 0
+
+- name: Check for extra peers not in inventory
+  ansible.builtin.set_fact:
+    wireguard_extra_peers: >-
+      {{
+        wireguard_actual_peer_keys | difference(wireguard_expected_peer_keys)
+      }}
+  when:
+    - wireguard_peers_list.rc == 0
+    - wireguard_actual_peer_keys is defined
+
+- name: Report extra peers (not in current inventory)
+  ansible.builtin.debug:
+    msg:
+      - "Found {{ wireguard_extra_peers | length }} peer(s) in WireGuard config that are not in inventory"
+      - "This is expected for partial deployments and helps preserve peer state"
+      - "Extra peers: {{ wireguard_extra_peers | map('regex_replace', '^(.{16}).*', '\\1...') | list }}"
+  when:
+    - wireguard_extra_peers is defined
+    - wireguard_extra_peers | length > 0
+
+- name: Validation summary
+  ansible.builtin.debug:
+    msg:
+      - "Peer validation complete:"
+      - "  Expected peers from inventory: {{ wireguard_expected_peer_keys | length }}"
+      - "  Actual configured peers: {{ wireguard_actual_peer_keys | default([]) | length }}"
+      - "  Extra peers preserved: {{ wireguard_extra_peers | default([]) | length }}"
+  when: wireguard_peers_list.rc == 0

--- a/roles/wireguard/templates/wg0.conf.j2
+++ b/roles/wireguard/templates/wg0.conf.j2
@@ -4,6 +4,7 @@ Address = {{ wireguard_ip }}/24
 ListenPort = {{ wireguard_port }}
 {% endif %}
 PrivateKey = {{ wireguard_private_key }}
+# PublicKey = {{ wireguard_public_key }}
 
 {% if inventory_hostname in groups['control_plane'] %}
 # Worker nodes

--- a/roles/wireguard/templates/wg0.conf.j2
+++ b/roles/wireguard/templates/wg0.conf.j2
@@ -7,6 +7,16 @@ PrivateKey = {{ wireguard_private_key }}
 
 {% if inventory_hostname in groups['control_plane'] %}
 # Worker nodes
+{% if wireguard_merged_peers is defined and wireguard_merged_peers | length > 0 %}
+{% for item in (wireguard_merged_peers | dict2items | sort(attribute='key')) %}
+[Peer]
+# {{ item.key }}
+PublicKey = {{ item.value.public_key }}
+AllowedIPs = {{ item.value.allowed_ips }}
+
+{% endfor %}
+{% else %}
+# Fallback to traditional method if wireguard_merged_peers not available
 {% for host in groups['workers'] %}
 [Peer]
 # {{ host }}
@@ -14,6 +24,7 @@ PublicKey = {{ hostvars[host]['wireguard_public_key'] }}
 AllowedIPs = {{ hostvars[host]['wireguard_ip'] }}/32
 
 {% endfor %}
+{% endif %}
 {% else %}
 # Control plane
 [Peer]

--- a/site.yml
+++ b/site.yml
@@ -101,7 +101,12 @@
 
     - name: Display key status
       ansible.builtin.debug:
-        msg: "{{ 'Using existing WireGuard keys from config' if wg_config_stat.stat.exists and not (wireguard_regenerate_keys | default(false) | bool) else 'Generated new WireGuard keys' }}"
+        msg: >-
+          {{
+            'Using existing WireGuard keys from config'
+            if wg_config_stat.stat.exists and not (wireguard_regenerate_keys | default(false) | bool)
+            else 'Generated new WireGuard keys'
+          }}
 
 - name: Configure WireGuard
   hosts: all

--- a/site.yml
+++ b/site.yml
@@ -70,6 +70,21 @@
   tags: wireguard
 
   tasks:
+    # Incremental peer configuration for control plane
+    - name: Fetch existing WireGuard peer state on control plane
+      ansible.builtin.include_tasks: roles/wireguard/tasks/fetch_existing_peers.yml
+      when: inventory_hostname in groups['control_plane']
+
+    - name: Merge peer configurations on control plane
+      ansible.builtin.include_tasks: roles/wireguard/tasks/merge_peer_config.yml
+      when: inventory_hostname in groups['control_plane']
+
+    # Dry-run mode: Generate config to temp location and show diff
+    - name: Generate WireGuard configuration preview (dry-run mode)
+      ansible.builtin.include_tasks: roles/wireguard/tasks/dry_run_config.yml
+      when: wireguard_dry_run | default(false) | bool
+
+    # Normal mode: Apply configuration
     - name: Create WireGuard configuration
       ansible.builtin.template:
         src: "roles/wireguard/templates/{{ wireguard_interface }}.conf.j2"
@@ -77,12 +92,14 @@
         mode: "0600"
         backup: true
       notify: Restart WireGuard
+      when: not (wireguard_dry_run | default(false) | bool)
 
     - name: Enable and start WireGuard service
       ansible.builtin.systemd:
         name: "wg-quick@{{ wireguard_interface }}"
         enabled: true
         state: started
+      when: not (wireguard_dry_run | default(false) | bool)
 
     - name: Install and configure UFW on all nodes
       ansible.builtin.package:
@@ -205,6 +222,14 @@
             state: enabled
             policy: deny
             direction: incoming
+
+    # Validate WireGuard peer configuration
+    - name: Validate WireGuard peer configuration on control plane
+      ansible.builtin.include_tasks: roles/wireguard/tasks/validate_peers.yml
+      when:
+        - inventory_hostname in groups['control_plane']
+        - not (wireguard_dry_run | default(false) | bool)
+
   handlers:
     - name: Restart WireGuard
       ansible.builtin.systemd:

--- a/site.yml
+++ b/site.yml
@@ -42,13 +42,47 @@
           - wireguard-tools
         state: present
 
-    - name: Generate WireGuard private key
+    - name: Check if WireGuard config exists
+      ansible.builtin.stat:
+        path: "/etc/wireguard/{{ wireguard_interface }}.conf"
+      register: wg_config_stat
+
+    - name: Read existing WireGuard configuration
+      ansible.builtin.slurp:
+        src: "/etc/wireguard/{{ wireguard_interface }}.conf"
+      register: wg_config_content
+      when: wg_config_stat.stat.exists
+      no_log: true
+
+    - name: Parse existing WireGuard configuration
+      ansible.builtin.set_fact:
+        wg_config_parsed: "{{ wg_config_content.content | b64decode | parse_wireguard_config }}"
+      when: wg_config_stat.stat.exists
+      no_log: true
+
+    - name: Extract existing keys from config
+      ansible.builtin.set_fact:
+        wireguard_private_key: "{{ wg_config_parsed.interface.privatekey | default('') }}"
+        wireguard_public_key: "{{ wg_config_parsed.interface.public_key | default('') }}"
+      when:
+        - wg_config_stat.stat.exists
+        - not (wireguard_regenerate_keys | default(false) | bool)
+        - wg_config_parsed.interface.privatekey is defined
+        - wg_config_parsed.interface.public_key is defined
+      no_log: true
+
+    - name: Generate new WireGuard private key
       ansible.builtin.command: wg genkey
       register: private_key
       changed_when: false
       no_log: true
+      when: >
+        not wg_config_stat.stat.exists or
+        (wireguard_regenerate_keys | default(false) | bool) or
+        wireguard_private_key is not defined or
+        wireguard_private_key == ''
 
-    - name: Generate WireGuard public key
+    - name: Generate new WireGuard public key
       ansible.builtin.shell:
         cmd: set -o pipefail && echo "{{ private_key.stdout }}" | wg pubkey
       args:
@@ -56,12 +90,18 @@
       register: public_key
       changed_when: false
       no_log: true
+      when: private_key is not skipped
 
-    - name: Store keys in facts
+    - name: Store newly generated keys in facts
       ansible.builtin.set_fact:
         wireguard_private_key: "{{ private_key.stdout }}"
         wireguard_public_key: "{{ public_key.stdout }}"
       no_log: true
+      when: private_key is not skipped
+
+    - name: Display key status
+      ansible.builtin.debug:
+        msg: "{{ 'Using existing WireGuard keys from config' if wg_config_stat.stat.exists and not (wireguard_regenerate_keys | default(false) | bool) else 'Generated new WireGuard keys' }}"
 
 - name: Configure WireGuard
   hosts: all

--- a/tests/test_wireguard_filters.py
+++ b/tests/test_wireguard_filters.py
@@ -1,0 +1,396 @@
+"""Table-driven tests for WireGuard filter plugins."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add filter_plugins to path so we can import the module
+sys.path.insert(0, str(Path(__file__).parent.parent / 'filter_plugins'))
+
+from wireguard_filters import (
+    parse_wireguard_config,
+    parse_wireguard_peers,
+    merge_wireguard_peers,
+    filter_peers_by_inventory,
+)
+
+
+class TestParseWireguardConfig:
+    """Table-driven tests for parse_wireguard_config filter."""
+
+    test_cases = [
+        (
+            "interface with public key comment",
+            """[Interface]
+Address = 10.0.0.20/24
+ListenPort = 51820
+PrivateKey = aDUMMYprivateKEY1234567890abcdefGHIJKLMNOP=
+# PublicKey = bDUMMYpublicKEY1234567890abcdefGHIJKLMNOPQ=
+
+[Peer]
+# test-worker-1
+PublicKey = cDUMMYpeerKEY1111111111abcdefGHIJKLMNOPQRST=
+AllowedIPs = 10.0.0.3/32
+""",
+            {
+                'interface': {
+                    'address': '10.0.0.20/24',
+                    'listenport': '51820',
+                    'privatekey': 'aDUMMYprivateKEY1234567890abcdefGHIJKLMNOP=',
+                    'public_key': 'bDUMMYpublicKEY1234567890abcdefGHIJKLMNOPQ=',
+                },
+                'peers': {
+                    'test-worker-1': {
+                        'public_key': 'cDUMMYpeerKEY1111111111abcdefGHIJKLMNOPQRST=',
+                        'allowed_ips': '10.0.0.3/32',
+                    }
+                }
+            },
+        ),
+        (
+            "interface without public key comment",
+            """[Interface]
+Address = 10.0.0.20/24
+PrivateKey = test_private_key_no_comment_dummy_data_123=
+
+[Peer]
+# test-worker-2
+PublicKey = dDUMMYpeerKEY2222222222abcdefGHIJKLMNOPQRST=
+AllowedIPs = 10.0.0.4/32
+""",
+            {
+                'interface': {
+                    'address': '10.0.0.20/24',
+                    'privatekey': 'test_private_key_no_comment_dummy_data_123=',
+                },
+                'peers': {
+                    'test-worker-2': {
+                        'public_key': 'dDUMMYpeerKEY2222222222abcdefGHIJKLMNOPQRST=',
+                        'allowed_ips': '10.0.0.4/32',
+                    }
+                }
+            },
+        ),
+        (
+            "empty config",
+            "",
+            {
+                'interface': {},
+                'peers': {}
+            },
+        ),
+    ]
+
+    @pytest.mark.parametrize("description,config,expected", test_cases)
+    def test_parse_wireguard_config(self, description, config, expected):
+        """Test parse_wireguard_config with various config formats."""
+        result = parse_wireguard_config(config)
+        assert result == expected, f"Failed: {description}"
+
+
+class TestParseWireguardPeers:
+    """Table-driven tests for parse_wireguard_peers filter."""
+
+    # Test cases: (description, input_config, expected_output)
+    test_cases = [
+        (
+            "empty config",
+            "",
+            {},
+        ),
+        (
+            "only whitespace",
+            "   \n  \n  ",
+            {},
+        ),
+        (
+            "interface only - no peers",
+            """[Interface]
+Address = 10.0.0.20/24
+PrivateKey = test_private_key
+""",
+            {},
+        ),
+        (
+            "single peer with comment name",
+            """[Interface]
+Address = 10.0.0.20/24
+PrivateKey = server_key
+
+[Peer]
+# test-worker-1
+PublicKey = eDUMMYworker1KEY11111111abcdefGHIJKLMNOPQRST=
+AllowedIPs = 10.0.0.3/32
+""",
+            {
+                'test-worker-1': {
+                    'public_key': 'eDUMMYworker1KEY11111111abcdefGHIJKLMNOPQRST=',
+                    'allowed_ips': '10.0.0.3/32',
+                }
+            },
+        ),
+        (
+            "single peer without comment - uses key prefix",
+            """[Interface]
+Address = 10.0.0.20/24
+PrivateKey = server_key
+
+[Peer]
+PublicKey = eDUMMYworker1KEY11111111abcdefGHIJKLMNOPQRST=
+AllowedIPs = 10.0.0.3/32
+""",
+            {
+                'eDUMMYworker': {
+                    'public_key': 'eDUMMYworker1KEY11111111abcdefGHIJKLMNOPQRST=',
+                    'allowed_ips': '10.0.0.3/32',
+                }
+            },
+        ),
+        (
+            "multiple peers with comments",
+            """[Interface]
+Address = 10.0.0.20/24
+ListenPort = 51820
+PrivateKey = server_key
+
+# Worker nodes
+[Peer]
+# test-worker-1
+PublicKey = eDUMMYworker1KEY11111111abcdefGHIJKLMNOPQRST=
+AllowedIPs = 10.0.0.3/32
+
+[Peer]
+# test-worker-2
+PublicKey = fDUMMYworker2KEY22222222abcdefGHIJKLMNOPQRST=
+AllowedIPs = 10.0.0.4/32
+
+[Peer]
+# test-worker-3
+PublicKey = gDUMMYworker3KEY33333333abcdefGHIJKLMNOPQRST=
+AllowedIPs = 10.0.0.21/32
+""",
+            {
+                'test-worker-1': {
+                    'public_key': 'eDUMMYworker1KEY11111111abcdefGHIJKLMNOPQRST=',
+                    'allowed_ips': '10.0.0.3/32',
+                },
+                'test-worker-2': {
+                    'public_key': 'fDUMMYworker2KEY22222222abcdefGHIJKLMNOPQRST=',
+                    'allowed_ips': '10.0.0.4/32',
+                },
+                'test-worker-3': {
+                    'public_key': 'gDUMMYworker3KEY33333333abcdefGHIJKLMNOPQRST=',
+                    'allowed_ips': '10.0.0.21/32',
+                },
+            },
+        ),
+        (
+            "peer with endpoint and keepalive",
+            """[Interface]
+Address = 10.0.0.3/24
+PrivateKey = client_key
+
+[Peer]
+# control-plane
+PublicKey = hDUMMYctrlplaneKEY4444444abcdefGHIJKLMNOPQ=
+Endpoint = test-control-plane.example.com:51820
+AllowedIPs = 10.0.0.0/24
+PersistentKeepalive = 25
+""",
+            {
+                'control-plane': {
+                    'public_key': 'hDUMMYctrlplaneKEY4444444abcdefGHIJKLMNOPQ=',
+                    'allowed_ips': '10.0.0.0/24',
+                    'endpoint': 'test-control-plane.example.com:51820',
+                    'persistent_keepalive': '25',
+                }
+            },
+        ),
+        (
+            "interface with public key comment",
+            """[Interface]
+Address = 10.0.0.20/24
+ListenPort = 51820
+PrivateKey = iDUMMYprivateKEYtest7777777abcdefGHIJKLMNOP=
+# PublicKey = hDUMMYctrlplaneKEY4444444abcdefGHIJKLMNOPQ=
+
+[Peer]
+# test-worker-1
+PublicKey = eDUMMYworker1KEY11111111abcdefGHIJKLMNOPQRST=
+AllowedIPs = 10.0.0.3/32
+""",
+            {
+                'test-worker-1': {
+                    'public_key': 'eDUMMYworker1KEY11111111abcdefGHIJKLMNOPQRST=',
+                    'allowed_ips': '10.0.0.3/32',
+                }
+            },
+        ),
+        (
+            "mixed case keys - normalized to lowercase",
+            """[Interface]
+Address = 10.0.0.20/24
+PrivateKey = test_key
+
+[Peer]
+# test-peer
+PublicKey = testpublickey123=
+AllowedIPs = 10.0.0.5/32
+PersistentKeepalive = 25
+""",
+            {
+                'test-peer': {
+                    'public_key': 'testpublickey123=',
+                    'allowed_ips': '10.0.0.5/32',
+                    'persistent_keepalive': '25',
+                }
+            },
+        ),
+    ]
+
+    @pytest.mark.parametrize("description,config,expected", test_cases)
+    def test_parse_wireguard_peers(self, description, config, expected):
+        """Test parse_wireguard_peers with various config formats."""
+        result = parse_wireguard_peers(config)
+        assert result == expected, f"Failed: {description}"
+
+    def test_none_input(self):
+        """Test that None input returns empty dict."""
+        assert parse_wireguard_peers(None) == {}
+
+
+class TestMergeWireguardPeers:
+    """Table-driven tests for merge_wireguard_peers filter."""
+
+    test_cases = [
+        (
+            "empty dicts",
+            {},
+            {},
+            {},
+        ),
+        (
+            "empty existing, new peers added",
+            {},
+            {
+                'test-worker-1': {'public_key': 'key1', 'allowed_ips': '10.0.0.3/32'},
+            },
+            {
+                'test-worker-1': {'public_key': 'key1', 'allowed_ips': '10.0.0.3/32'},
+            },
+        ),
+        (
+            "existing peers, empty new",
+            {
+                'test-worker-1': {'public_key': 'key1', 'allowed_ips': '10.0.0.3/32'},
+            },
+            {},
+            {
+                'test-worker-1': {'public_key': 'key1', 'allowed_ips': '10.0.0.3/32'},
+            },
+        ),
+        (
+            "non-overlapping peers - all preserved",
+            {
+                'test-worker-1': {'public_key': 'key1', 'allowed_ips': '10.0.0.3/32'},
+                'test-worker-2': {'public_key': 'key2', 'allowed_ips': '10.0.0.4/32'},
+            },
+            {
+                'test-worker-3': {'public_key': 'key3', 'allowed_ips': '10.0.0.21/32'},
+            },
+            {
+                'test-worker-1': {'public_key': 'key1', 'allowed_ips': '10.0.0.3/32'},
+                'test-worker-2': {'public_key': 'key2', 'allowed_ips': '10.0.0.4/32'},
+                'test-worker-3': {'public_key': 'key3', 'allowed_ips': '10.0.0.21/32'},
+            },
+        ),
+        (
+            "overlapping peers - new overrides existing",
+            {
+                'test-worker-1': {'public_key': 'old_key', 'allowed_ips': '10.0.0.3/32'},
+                'test-worker-2': {'public_key': 'key2', 'allowed_ips': '10.0.0.4/32'},
+            },
+            {
+                'test-worker-1': {'public_key': 'new_key', 'allowed_ips': '10.0.0.3/32'},
+            },
+            {
+                'test-worker-1': {'public_key': 'new_key', 'allowed_ips': '10.0.0.3/32'},
+                'test-worker-2': {'public_key': 'key2', 'allowed_ips': '10.0.0.4/32'},
+            },
+        ),
+        (
+            "None inputs treated as empty",
+            None,
+            None,
+            {},
+        ),
+    ]
+
+    @pytest.mark.parametrize("description,existing,new,expected", test_cases)
+    def test_merge_wireguard_peers(self, description, existing, new, expected):
+        """Test merge_wireguard_peers with various scenarios."""
+        result = merge_wireguard_peers(existing, new)
+        assert result == expected, f"Failed: {description}"
+
+
+class TestFilterPeersByInventory:
+    """Table-driven tests for filter_peers_by_inventory filter."""
+
+    test_cases = [
+        (
+            "empty peers and inventory",
+            {},
+            [],
+            {},
+        ),
+        (
+            "empty inventory - all peers preserved",
+            {
+                'test-worker-1': {'public_key': 'key1', 'allowed_ips': '10.0.0.3/32'},
+                'test-worker-2': {'public_key': 'key2', 'allowed_ips': '10.0.0.4/32'},
+            },
+            [],
+            {
+                'test-worker-1': {'public_key': 'key1', 'allowed_ips': '10.0.0.3/32'},
+                'test-worker-2': {'public_key': 'key2', 'allowed_ips': '10.0.0.4/32'},
+            },
+        ),
+        (
+            "filter to inventory subset",
+            {
+                'test-worker-1': {'public_key': 'key1', 'allowed_ips': '10.0.0.3/32'},
+                'test-worker-2': {'public_key': 'key2', 'allowed_ips': '10.0.0.4/32'},
+                'test-worker-3': {'public_key': 'key3', 'allowed_ips': '10.0.0.21/32'},
+            },
+            ['test-worker-1', 'test-worker-2'],
+            {
+                'test-worker-1': {'public_key': 'key1', 'allowed_ips': '10.0.0.3/32'},
+                'test-worker-2': {'public_key': 'key2', 'allowed_ips': '10.0.0.4/32'},
+            },
+        ),
+        (
+            "no matching peers",
+            {
+                'test-worker-1': {'public_key': 'key1', 'allowed_ips': '10.0.0.3/32'},
+            },
+            ['other-host'],
+            {},
+        ),
+        (
+            "None peers input",
+            None,
+            ['test-worker-1'],
+            {},
+        ),
+    ]
+
+    @pytest.mark.parametrize("description,peers,inventory,expected", test_cases)
+    def test_filter_peers_by_inventory(self, description, peers, inventory, expected):
+        """Test filter_peers_by_inventory with various scenarios."""
+        result = filter_peers_by_inventory(peers, inventory)
+        assert result == expected, f"Failed: {description}"
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/tests/test_wireguard_template.py
+++ b/tests/test_wireguard_template.py
@@ -1,0 +1,284 @@
+"""Table-driven tests for WireGuard configuration template (wg0.conf.j2) rendering."""
+
+import sys
+from pathlib import Path
+
+import pytest
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+# Add filter_plugins to path for custom filters
+sys.path.insert(0, str(Path(__file__).parent.parent / 'filter_plugins'))
+
+
+class TestWireguardTemplate:
+    """Table-driven tests for wg0.conf.j2 template rendering."""
+
+    @pytest.fixture
+    def jinja_env(self):
+        """Set up Jinja2 environment with template directory and custom filters."""
+        template_dir = Path(__file__).parent.parent / 'roles' / 'wireguard' / 'templates'
+        env = Environment(
+            loader=FileSystemLoader(str(template_dir)),
+            undefined=StrictUndefined,
+            trim_blocks=True,
+            lstrip_blocks=True,
+            keep_trailing_newline=True,
+        )
+        # Register dict2items filter (Ansible built-in)
+        env.filters['dict2items'] = lambda d: [{'key': k, 'value': v} for k, v in sorted(d.items())]
+        return env
+
+    # Test cases: (description, context, expected_output)
+    test_cases = [
+        (
+            "control plane with single worker using merged peers",
+            {
+                'inventory_hostname': 'test-control',
+                'groups': {
+                    'control_plane': ['test-control'],
+                    'workers': ['test-worker-1'],
+                },
+                'wireguard_ip': '10.0.0.20',
+                'wireguard_port': 51820,
+                'wireguard_private_key': 'aDUMMYprivateKEY1234567890abcdefGHIJKLMNOP=',
+                'wireguard_public_key': 'bDUMMYpublicKEY1234567890abcdefGHIJKLMNOPQ=',
+                'wireguard_merged_peers': {
+                    'test-worker-1': {
+                        'public_key': 'cDUMMYpeerKEY1111111111abcdefGHIJKLMNOPQRST=',
+                        'allowed_ips': '10.0.0.3/32',
+                    },
+                },
+            },
+            """[Interface]
+Address = 10.0.0.20/24
+ListenPort = 51820
+PrivateKey = aDUMMYprivateKEY1234567890abcdefGHIJKLMNOP=
+# PublicKey = bDUMMYpublicKEY1234567890abcdefGHIJKLMNOPQ=
+
+# Worker nodes
+[Peer]
+# test-worker-1
+PublicKey = cDUMMYpeerKEY1111111111abcdefGHIJKLMNOPQRST=
+AllowedIPs = 10.0.0.3/32
+
+
+""",
+        ),
+        (
+            "control plane with multiple workers sorted alphabetically",
+            {
+                'inventory_hostname': 'test-control',
+                'groups': {
+                    'control_plane': ['test-control'],
+                    'workers': ['worker-c', 'worker-a', 'worker-b'],
+                },
+                'wireguard_ip': '10.0.0.20',
+                'wireguard_port': 51820,
+                'wireguard_private_key': 'aDUMMYprivateKEY1234567890abcdefGHIJKLMNOP=',
+                'wireguard_public_key': 'bDUMMYpublicKEY1234567890abcdefGHIJKLMNOPQ=',
+                'wireguard_merged_peers': {
+                    'worker-c': {
+                        'public_key': 'cDUMMYworkerCKEY3333333333abcdefGHIJKLMNOP=',
+                        'allowed_ips': '10.0.0.5/32',
+                    },
+                    'worker-a': {
+                        'public_key': 'cDUMMYworkerAKEY1111111111abcdefGHIJKLMNOP=',
+                        'allowed_ips': '10.0.0.3/32',
+                    },
+                    'worker-b': {
+                        'public_key': 'cDUMMYworkerBKEY2222222222abcdefGHIJKLMNOP=',
+                        'allowed_ips': '10.0.0.4/32',
+                    },
+                },
+            },
+            """[Interface]
+Address = 10.0.0.20/24
+ListenPort = 51820
+PrivateKey = aDUMMYprivateKEY1234567890abcdefGHIJKLMNOP=
+# PublicKey = bDUMMYpublicKEY1234567890abcdefGHIJKLMNOPQ=
+
+# Worker nodes
+[Peer]
+# worker-a
+PublicKey = cDUMMYworkerAKEY1111111111abcdefGHIJKLMNOP=
+AllowedIPs = 10.0.0.3/32
+
+[Peer]
+# worker-b
+PublicKey = cDUMMYworkerBKEY2222222222abcdefGHIJKLMNOP=
+AllowedIPs = 10.0.0.4/32
+
+[Peer]
+# worker-c
+PublicKey = cDUMMYworkerCKEY3333333333abcdefGHIJKLMNOP=
+AllowedIPs = 10.0.0.5/32
+
+
+""",
+        ),
+        (
+            "control plane with empty merged peers uses fallback",
+            {
+                'inventory_hostname': 'test-control',
+                'groups': {
+                    'control_plane': ['test-control'],
+                    'workers': ['test-worker-1', 'test-worker-2'],
+                },
+                'wireguard_ip': '10.0.0.20',
+                'wireguard_port': 51820,
+                'wireguard_private_key': 'aDUMMYprivateKEY1234567890abcdefGHIJKLMNOP=',
+                'wireguard_public_key': 'bDUMMYpublicKEY1234567890abcdefGHIJKLMNOPQ=',
+                'wireguard_merged_peers': {},
+                'hostvars': {
+                    'test-worker-1': {
+                        'wireguard_public_key': 'eDUMMYworker1KEY11111111abcdefGHIJKLMNOPQRST=',
+                        'wireguard_ip': '10.0.0.3',
+                    },
+                    'test-worker-2': {
+                        'wireguard_public_key': 'fDUMMYworker2KEY22222222abcdefGHIJKLMNOPQRST=',
+                        'wireguard_ip': '10.0.0.4',
+                    },
+                },
+            },
+            """[Interface]
+Address = 10.0.0.20/24
+ListenPort = 51820
+PrivateKey = aDUMMYprivateKEY1234567890abcdefGHIJKLMNOP=
+# PublicKey = bDUMMYpublicKEY1234567890abcdefGHIJKLMNOPQ=
+
+# Worker nodes
+# Fallback to traditional method if wireguard_merged_peers not available
+[Peer]
+# test-worker-1
+PublicKey = eDUMMYworker1KEY11111111abcdefGHIJKLMNOPQRST=
+AllowedIPs = 10.0.0.3/32
+
+[Peer]
+# test-worker-2
+PublicKey = fDUMMYworker2KEY22222222abcdefGHIJKLMNOPQRST=
+AllowedIPs = 10.0.0.4/32
+
+
+""",
+        ),
+        (
+            "control plane without merged peers variable uses fallback",
+            {
+                'inventory_hostname': 'test-control',
+                'groups': {
+                    'control_plane': ['test-control'],
+                    'workers': ['test-worker-1'],
+                },
+                'wireguard_ip': '10.0.0.20',
+                'wireguard_port': 51820,
+                'wireguard_private_key': 'aDUMMYprivateKEY1234567890abcdefGHIJKLMNOP=',
+                'wireguard_public_key': 'bDUMMYpublicKEY1234567890abcdefGHIJKLMNOPQ=',
+                'hostvars': {
+                    'test-worker-1': {
+                        'wireguard_public_key': 'eDUMMYworker1KEY11111111abcdefGHIJKLMNOPQRST=',
+                        'wireguard_ip': '10.0.0.3',
+                    },
+                },
+            },
+            """[Interface]
+Address = 10.0.0.20/24
+ListenPort = 51820
+PrivateKey = aDUMMYprivateKEY1234567890abcdefGHIJKLMNOP=
+# PublicKey = bDUMMYpublicKEY1234567890abcdefGHIJKLMNOPQ=
+
+# Worker nodes
+# Fallback to traditional method if wireguard_merged_peers not available
+[Peer]
+# test-worker-1
+PublicKey = eDUMMYworker1KEY11111111abcdefGHIJKLMNOPQRST=
+AllowedIPs = 10.0.0.3/32
+
+
+""",
+        ),
+        (
+            "worker node config with control plane peer",
+            {
+                'inventory_hostname': 'test-worker-1',
+                'groups': {
+                    'control_plane': ['test-control'],
+                    'workers': ['test-worker-1', 'test-worker-2'],
+                },
+                'wireguard_ip': '10.0.0.3',
+                'wireguard_private_key': 'wDUMMYworker1privateKEY123456abcdefGHIJKLM=',
+                'wireguard_public_key': 'wDUMMYworker1publicKEY123456abcdefGHIJKLMN=',
+                'wireguard_network': '10.0.0.0/24',
+                'hostvars': {
+                    'test-control': {
+                        'wireguard_public_key': 'hDUMMYctrlplaneKEY4444444abcdefGHIJKLMNOPQ=',
+                        'ansible_host': 'test-control-plane.example.com',
+                        'wireguard_port': 51820,
+                    },
+                },
+            },
+            """[Interface]
+Address = 10.0.0.3/24
+PrivateKey = wDUMMYworker1privateKEY123456abcdefGHIJKLM=
+# PublicKey = wDUMMYworker1publicKEY123456abcdefGHIJKLMN=
+
+# Control plane
+[Peer]
+PublicKey = hDUMMYctrlplaneKEY4444444abcdefGHIJKLMNOPQ=
+Endpoint = root.test-control-plane.example.com:51820
+AllowedIPs = 10.0.0.0/24
+PersistentKeepalive = 25
+
+""",
+        ),
+        (
+            "control plane with no workers - empty config",
+            {
+                'inventory_hostname': 'test-control',
+                'groups': {
+                    'control_plane': ['test-control'],
+                    'workers': [],
+                },
+                'wireguard_ip': '10.0.0.20',
+                'wireguard_port': 51820,
+                'wireguard_private_key': 'aDUMMYprivateKEY1234567890abcdefGHIJKLMNOP=',
+                'wireguard_public_key': 'bDUMMYpublicKEY1234567890abcdefGHIJKLMNOPQ=',
+                'wireguard_merged_peers': {},
+                'hostvars': {},
+            },
+            """[Interface]
+Address = 10.0.0.20/24
+ListenPort = 51820
+PrivateKey = aDUMMYprivateKEY1234567890abcdefGHIJKLMNOP=
+# PublicKey = bDUMMYpublicKEY1234567890abcdefGHIJKLMNOPQ=
+
+# Worker nodes
+# Fallback to traditional method if wireguard_merged_peers not available
+
+""",
+        ),
+    ]
+
+    @pytest.mark.parametrize("description,context,expected", test_cases)
+    def test_template_rendering(self, jinja_env, description, context, expected):
+        """Test template rendering with diff-based assertion."""
+        template = jinja_env.get_template('wg0.conf.j2')
+        actual = template.render(context)
+
+        # Use unified diff for clear comparison
+        if actual != expected:
+            import difflib
+            diff = '\n'.join(difflib.unified_diff(
+                expected.splitlines(keepends=True),
+                actual.splitlines(keepends=True),
+                fromfile='expected',
+                tofile='actual',
+                lineterm='',
+            ))
+            pytest.fail(f"Template output mismatch for: {description}\n\n{diff}")
+
+        # Also do strict equality check
+        assert actual == expected, f"Failed: {description}"
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/uv.lock
+++ b/uv.lock
@@ -40,12 +40,14 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "ansible-lint" },
+    { name = "jinja2" },
     { name = "pytest" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "ansible-lint", specifier = ">=25.7.0" },
+    { name = "jinja2", specifier = ">=3.1.0" },
     { name = "pytest", specifier = ">=8.0.0" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -40,10 +40,14 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "ansible-lint" },
+    { name = "pytest" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "ansible-lint", specifier = ">=25.7.0" }]
+requires-dist = [
+    { name = "ansible-lint", specifier = ">=25.7.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
+]
 
 [[package]]
 name = "ansible-lint"
@@ -208,6 +212,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -311,12 +324,46 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "2.22"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736, upload-time = "2024-03-30T13:22:22.564Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552, upload-time = "2024-03-30T13:22:20.476Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR introduces WireGuard incremental peer update capability, allowing partial worker node deployments without losing peer configurations on the control plane. It includes dry-run mode for previewing changes and comprehensive test coverage.

### Key Features

- **Incremental Peer Updates**: Deploy workers one at a time without overwriting existing peer configurations on control plane
- **Key Reuse Logic**: Automatically extract and reuse existing WireGuard keys from config files (unless `wireguard_regenerate_keys=true`)
- **Dry-Run Mode**: Preview configuration changes before applying them with `just dry-run [host]`
- **Comprehensive Testing**: Table-driven tests with diff-based assertions for both filter plugins and template rendering

### Implementation Details

#### 1. WireGuard Incremental Updates
- New tasks: `fetch_existing_peers.yml`, `merge_peer_config.yml`, `validate_peers.yml`
- Custom filter plugins: `parse_wireguard_config`, `parse_wireguard_peers`, `merge_wireguard_peers`
- Template updated to use `wireguard_merged_peers` with fallback to traditional method
- Automatically sorts peers alphabetically for consistent output

#### 2. Key Reuse Logic
- Extracts existing public/private keys from `/etc/wireguard/wg0.conf` if present
- Adds public key as comment in [Interface] section for easy extraction
- Only regenerates keys when explicitly requested or when config doesn't exist

#### 3. Dry-Run Mode
- New `just dry-run [host]` command for previewing changes
- Generates config to `/tmp/wg0.conf.preview` without applying
- Automatically includes control plane when running dry-run on worker nodes
- Shows configuration diff for review

#### 4. Test Coverage
- **Filter Plugin Tests** (24 tests): Comprehensive table-driven tests for all custom filters
- **Template Rendering Tests** (6 tests): Full coverage of control plane and worker configurations
- All tests use dummy data (no real secrets)
- Diff-based assertions for strict line-by-line validation

### Files Changed

**New Files:**
- `roles/wireguard/tasks/fetch_existing_peers.yml` - Fetch current peer configurations
- `roles/wireguard/tasks/merge_peer_config.yml` - Merge new and existing peers
- `roles/wireguard/tasks/validate_peers.yml` - Validate merged configuration
- `roles/wireguard/tasks/dry_run_config.yml` - Dry-run preview mode
- `filter_plugins/wireguard_filters.py` - Custom Ansible filters
- `tests/test_wireguard_filters.py` - Filter plugin tests
- `tests/test_wireguard_template.py` - Template rendering tests

**Modified Files:**
- `roles/wireguard/tasks/main.yml` - Added incremental update workflow
- `roles/wireguard/templates/wg0.conf.j2` - Support merged peers and key reuse
- `justfile` - Added `dry-run` and `test` commands
- `pyproject.toml` - Added pytest and jinja2 dependencies

### Test Plan

- [x] All 30 tests passing (24 filter tests + 6 template tests)
- [x] Dry-run mode tested on control plane and worker nodes
- [x] Incremental deployment tested with multiple workers
- [x] Key reuse verified on existing configurations
- [x] Template rendering produces correct WireGuard configs
- [x] No secrets committed in test data

### Usage Examples

```bash
# Preview changes before deploying
just dry-run k8s-proxy

# Deploy single worker without affecting other peers
just deploy k8s-proxy

# Run all tests
just test

# Force key regeneration
uv run ansible-playbook -i inventory.yml site.yml --tags=wireguard -e "wireguard_regenerate_keys=true"
```

### Breaking Changes

None. The implementation maintains backward compatibility with existing deployments.