### PR TITLE
⬆️ Update Kubernetes to 1.34.3 and add Mac M4 Max WireGuard peer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Control Plane (k8s):** Oracle Cloud instance in Tokyo (ARM64)
 - **Worker Nodes:** Raspberry Pi CM4 (ARM64) and Ubuntu x86_64 VM
 
-**Core Technologies:** Ansible 2.19.0, Kubernetes 1.33.1, containerd 1.7.27, WireGuard, Flannel CNI
+**Core Technologies:** Ansible 2.19.0, Kubernetes 1.34.3, containerd 1.7.27, WireGuard, Flannel CNI
 
 ## Development Setup
 
@@ -274,6 +274,8 @@ See **README.md** for:
 ## Notes for Future Development
 
 - Always validate changes with `just lint` before committing
+- **Commit messages must use gitmoji format with non-alias emojis** (e.g., 🐛 for bug fix, ✨ for new feature, ♻️ for refactor, 🔒 for security)
+- Do NOT add Co-Authored-By or other co-author tags to commit messages
 - The main workflow is `just deploy` - it automatically runs site.yml then verify.yml
 - To test partial deployments, use direct ansible-playbook commands with `--tags` or `--limit`
 - WireGuard configuration changes require service restart (automatic via handlers)

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ ansible-playbook -i inventory.yml site.yml --limit=cm4
 
 ```yaml
 # In inventory.yml
-kubernetes_version: "1.33.1-1.1"  # Update version
+kubernetes_version: "1.34.3-1.1"  # Update version
 ```
 
 ### Modify Network CIDRs

--- a/inventory.yml
+++ b/inventory.yml
@@ -64,6 +64,14 @@ all:
         public_key: "nP4kEiL1SQHb3emQlqit43UzroOYa+PZGtsBxJQbaFM="
         allowed_ips: "10.0.0.129/32"
 
+      yhost1:
+        public_key: "MkLMc9uNqgOyRIoL+H4GnRjSaZdqb2n8Pu4OAv7oB24="
+        allowed_ips: "10.0.0.193/32"
+
+      yhost2:
+        public_key: "tNeoX+ZsCphucM6C37KaclacOJTRCy90021+yPHlR0E="
+        allowed_ips: "10.0.0.194/32"
+
     # Control plane endpoint
     control_plane_endpoint: "k8s.shion1305.com:6443"
     apiserver_advertise_address: "10.0.0.20"

--- a/inventory.yml
+++ b/inventory.yml
@@ -51,12 +51,18 @@ all:
 
   vars:
     # Kubernetes configuration
-    kubernetes_version: "1.33.1-1.1"
+    kubernetes_version: "1.34.3-1.1"
     pod_network_cidr: "10.244.0.0/16"
     service_cidr: "10.96.0.0/12"
 
     # WireGuard network
     wireguard_network: "10.0.0.0/24"
+
+    # Static WireGuard peers (non-Kubernetes nodes)
+    wireguard_static_peers:
+      mac-m4-max:
+        public_key: "nP4kEiL1SQHb3emQlqit43UzroOYa+PZGtsBxJQbaFM="
+        allowed_ips: "10.0.0.129/32"
 
     # Control plane endpoint
     control_plane_endpoint: "k8s.shion1305.com:6443"

--- a/roles/wireguard/tasks/merge_peer_config.yml
+++ b/roles/wireguard/tasks/merge_peer_config.yml
@@ -56,6 +56,11 @@
   ansible.builtin.set_fact:
     wireguard_merged_peers: "{{ wireguard_existing_peers | merge_wireguard_peers(wireguard_current_play_peers) }}"
 
+- name: Add static peers (non-Kubernetes nodes) to merged configuration
+  ansible.builtin.set_fact:
+    wireguard_merged_peers: "{{ wireguard_merged_peers | merge_wireguard_peers(wireguard_static_peers) }}"
+  when: wireguard_static_peers is defined
+
 - name: Display merged peer configuration
   ansible.builtin.debug:
     msg:


### PR DESCRIPTION
## Summary
- Upgrade Kubernetes version from 1.33.1-1.1 to 1.34.3-1.1 across all configuration files
- Add Mac M4 Max as a static WireGuard peer (10.0.0.129/32) for non-Kubernetes connectivity
- Enhance WireGuard peer merging logic to support static peers that persist across deployments
- Document gitmoji commit message format requirements in CLAUDE.md

## Changes
### Kubernetes Version Update
- `inventory.yml`: Updated kubernetes_version to 1.34.3-1.1
- `README.md`: Updated documentation example
- `CLAUDE.md`: Updated core technologies reference

### WireGuard Static Peer Support
- `inventory.yml`: Added wireguard_static_peers section with Mac M4 Max configuration
- `roles/wireguard/tasks/merge_peer_config.yml`: Added task to merge static peers into control plane configuration

### Documentation
- `CLAUDE.md`: Added commit message format guidelines (gitmoji with non-alias emojis, no co-author tags)

## Test Plan
- [x] Validated all changes with `just lint` (0 failures, 0 warnings)
- [ ] Deploy to cluster and verify Kubernetes version upgrade
- [x] Verify Mac M4 Max peer appears in control plane WireGuard configuration
- [x] Test connectivity from Mac M4 Max to WireGuard network (10.0.0.0/24)