### PR TITLE
🔧 Migrate Kubernetes APT repo to v1.34 with modern signed-by keyring

### DIFF
--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -16,13 +16,12 @@
     cmd: gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg /etc/apt/keyrings/kubernetes-apt-keyring-armored.key
     creates: /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 
-- name: Remove old Kubernetes APT sources (v1.33 and legacy formats)
+- name: Ensure Kubernetes APT keyring permissions are deterministic
   ansible.builtin.file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - /etc/apt/sources.list.d/pkgs_k8s_io_core_stable_v1_33_deb.list
-    - /etc/apt/sources.list.d/pkgs_k8s_io_core_stable_v1_34_deb.list
+    path: /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+    mode: "0644"
+    owner: root
+    group: root
 
 - name: Add Kubernetes APT repository with signed-by
   ansible.builtin.apt_repository:

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -10,14 +10,11 @@
     url: https://pkgs.k8s.io/core:/stable:/v1.34/deb/Release.key
     dest: /etc/apt/keyrings/kubernetes-apt-keyring-armored.key
     mode: "0644"
-    force: true
-  register: kubernetes_apt_key_download
 
 - name: Dearmor Kubernetes APT repository signing key
-  ansible.builtin.shell:
-    cmd: gpg --dearmor < /etc/apt/keyrings/kubernetes-apt-keyring-armored.key > /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-  when: kubernetes_apt_key_download.changed
-  changed_when: true
+  ansible.builtin.command:
+    cmd: gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg /etc/apt/keyrings/kubernetes-apt-keyring-armored.key
+    creates: /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 
 - name: Remove old Kubernetes APT sources (v1.33 and legacy formats)
   ansible.builtin.file:

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Add Kubernetes APT repository key
   ansible.builtin.apt_key:
-    url: https://pkgs.k8s.io/core:/stable:/v1.33/deb/Release.key
+    url: https://pkgs.k8s.io/core:/stable:/v1.34/deb/Release.key
     state: present
 
 - name: Add Kubernetes APT repository
   ansible.builtin.apt_repository:
-    repo: "deb https://pkgs.k8s.io/core:/stable:/v1.33/deb/ /"
+    repo: "deb https://pkgs.k8s.io/core:/stable:/v1.34/deb/ /"
     state: present
 
 - name: Install containerd

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -1,13 +1,38 @@
 ---
-- name: Add Kubernetes APT repository key
-  ansible.builtin.apt_key:
-    url: https://pkgs.k8s.io/core:/stable:/v1.34/deb/Release.key
-    state: present
+- name: Create keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
 
-- name: Add Kubernetes APT repository
+- name: Download Kubernetes APT repository signing key
+  ansible.builtin.get_url:
+    url: https://pkgs.k8s.io/core:/stable:/v1.34/deb/Release.key
+    dest: /etc/apt/keyrings/kubernetes-apt-keyring-armored.key
+    mode: "0644"
+    force: true
+  register: kubernetes_apt_key_download
+
+- name: Dearmor Kubernetes APT repository signing key
+  ansible.builtin.shell:
+    cmd: gpg --dearmor < /etc/apt/keyrings/kubernetes-apt-keyring-armored.key > /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+  when: kubernetes_apt_key_download.changed
+  changed_when: true
+
+- name: Remove old Kubernetes APT sources (v1.33 and legacy formats)
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /etc/apt/sources.list.d/pkgs_k8s_io_core_stable_v1_33_deb.list
+    - /etc/apt/sources.list.d/pkgs_k8s_io_core_stable_v1_34_deb.list
+
+- name: Add Kubernetes APT repository with signed-by
   ansible.builtin.apt_repository:
-    repo: "deb https://pkgs.k8s.io/core:/stable:/v1.34/deb/ /"
+    repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.34/deb/ /"
+    filename: kubernetes
     state: present
+    update_cache: true
 
 - name: Install containerd
   ansible.builtin.package:

--- a/site.yml
+++ b/site.yml
@@ -8,6 +8,14 @@
   gather_facts: true
 
   pre_tasks:
+    - name: Remove legacy Kubernetes APT sources to prevent Signed-By conflicts
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /etc/apt/sources.list.d/pkgs_k8s_io_core_stable_v1_33_deb.list
+        - /etc/apt/sources.list.d/pkgs_k8s_io_core_stable_v1_34_deb.list
+
     - name: Update apt cache (Debian/Ubuntu)
       ansible.builtin.apt:
         update_cache: true


### PR DESCRIPTION
## Summary

- **Migrate Kubernetes APT repository from v1.33 to v1.34** to match the configured `kubernetes_version: 1.34.3-1.1`
- **Replace deprecated `apt_key` module** with the modern `get_url` + `gpg --dearmor` approach using `/etc/apt/keyrings/`
- **Clean up stale legacy APT source files** (`pkgs_k8s_io_core_stable_v1_33_deb.list`, etc.) to prevent `Signed-By` conflicts between legacy and modern formats
- Use shell redirection for `gpg --dearmor` to avoid interactive tty prompts when overwriting existing keyrings

## Context

Deploying a fresh node (`k8s-proxy`) failed with `no available installation candidate for kubelet=1.34.3-1.1` because the APT repo was pointing to v1.33. Existing nodes didn't fail because packages were already installed. Additionally, mixing the deprecated `apt_key` with existing `signed-by` configurations caused APT conflicts that blocked even `apt update`.

## Test plan

- [x] Deployed `k8s-proxy` from scratch successfully
- [x] All 4 nodes Ready
- [x] 10/10 system pods running, 4/4 Flannel pods running
- [x] WireGuard connectivity verified
- [x] Idempotent re-run on existing nodes (`k8s`) passes without errors