### PR TITLE
🧱 Onboard @tomoyahiroe's macbook air

### DIFF
--- a/inventory.yml
+++ b/inventory.yml
@@ -64,6 +64,10 @@ all:
         public_key: "nP4kEiL1SQHb3emQlqit43UzroOYa+PZGtsBxJQbaFM="
         allowed_ips: "10.130.5.129/32"
 
+      tomoya-mac:
+        public_key: "+6KaWGZ4ePBZPhQJhGrMK4qU837OzXvNe86nntx1kno="
+        allowed_ips: "10.130.5.130/32"
+
       yhost1:
         public_key: "MkLMc9uNqgOyRIoL+H4GnRjSaZdqb2n8Pu4OAv7oB24="
         allowed_ips: "10.130.5.193/32"


### PR DESCRIPTION
## Summary
- Add `tomoya-mac` as a static WireGuard peer in inventory with IP `10.130.5.130/32`

## Test plan
- [x] Ran `just deploy` — all 4 nodes deployed successfully with 0 failures
- [x] WireGuard verification passed — new peer merged into control plane config (8 total peers)
- [x] Cluster verification: 4/4 nodes Ready, 10/10 system pods running, 4/4 Flannel pods running