### PR TITLE
♻️ Remove unused local_ip; unify kubelet node-ip on wireguard_ip

### DIFF
--- a/inventory.yml
+++ b/inventory.yml
@@ -7,7 +7,6 @@ all:
           ansible_host: k8s.shion1305.com
           ansible_user: ubuntu
           ansible_ssh_private_key_file: ~/.ssh/credentials/shion1305-oci
-          local_ip: 10.130.5.1
           wireguard_ip: 10.130.5.1
           architecture: arm64
           wireguard_interface: wg0
@@ -20,7 +19,6 @@ all:
           ansible_host: cm4
           ansible_user: shion
           ansible_ssh_private_key_file: ~/.ssh/credentials/rasp-cm4
-          local_ip: 192.168.11.7
           wireguard_ip: 10.130.5.3
           architecture: arm64
           wireguard_interface: wg0
@@ -31,7 +29,6 @@ all:
           ansible_host: s2204
           ansible_user: shion
           ansible_ssh_private_key_file: ~/.ssh/credentials/shion1305
-          local_ip: 192.168.11.2
           wireguard_ip: 10.130.5.4
           architecture: amd64
           wireguard_interface: wg0
@@ -42,7 +39,6 @@ all:
           ansible_host: prox
           ansible_user: ubuntu
           ansible_ssh_private_key_file: ~/.ssh/credentials/shion1305-oci
-          local_ip: 10.130.5.21
           wireguard_ip: 10.130.5.21
           architecture: arm64
           wireguard_interface: wg0

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -91,19 +91,6 @@
     group: root
     create: true
   notify: Restart kubelet
-  when: inventory_hostname in groups['workers']
-
-- name: Configure kubelet node IP for control plane
-  ansible.builtin.lineinfile:
-    path: /etc/default/kubelet
-    regexp: "^KUBELET_EXTRA_ARGS="
-    line: 'KUBELET_EXTRA_ARGS="--node-ip={{ local_ip }}"'
-    mode: "0644"
-    owner: root
-    group: root
-    create: true
-  notify: Restart kubelet
-  when: inventory_hostname in groups['control_plane']
 
 - name: Enable and start services
   ansible.builtin.systemd:


### PR DESCRIPTION
## Summary

`local_ip` was an inventory variable referenced in exactly one place — the kubelet `--node-ip` configuration — and only on the **control-plane** branch, where its value equaled `wireguard_ip` (`10.130.5.1`). On worker hosts `local_ip` was a **dead value**: workers already configured `--node-ip` from `wireguard_ip`. (This is why the freshly-reinstalled cm4 registered with its `wireguard_ip` `10.130.5.3` even though its `local_ip` still read the stale `192.168.11.7`.)

This removes the redundant/confusing field and unifies the kubelet node-ip logic.

## Changes

- **`inventory.yml`** — drop `local_ip` from all four hosts.
- **`roles/kubernetes/tasks/main.yml`** — point the control-plane kubelet `--node-ip` at `wireguard_ip`. Since the worker and control-plane tasks then become identical, collapse them into a single unconditional `Configure kubelet node IP` task.

## Why it's safe

Functionally equivalent — for the control plane `local_ip == wireguard_ip == 10.130.5.1`, so the rendered `KUBELET_EXTRA_ARGS` line is unchanged. On the next deploy the `lineinfile` is a no-op: no kubelet restart, no node re-registration.

## Test plan

- [x] `just lint` passes (production profile, 0 failures on 43 files)
- [x] No remaining `local_ip` references in the repo
- [ ] `just deploy` to confirm the kubelet node-ip line is unchanged on the live nodes