### PR TITLE
✨ Add per-node kubelet resource reservations

### DIFF
--- a/inventory.yml
+++ b/inventory.yml
@@ -12,6 +12,10 @@ all:
           wireguard_interface: wg0
           wireguard_port: 51820
           cni_version: v1.3.0
+          # 2 vCPU / 12Gi: memory-only reservation (avoid reserving scarce CPU)
+          kubelet_kube_reserved: "memory=512Mi"
+          kubelet_system_reserved: "memory=512Mi"
+          kubelet_eviction_hard: "memory.available<500Mi,nodefs.available<10%,imagefs.available<15%"
 
     workers:
       hosts:
@@ -24,6 +28,10 @@ all:
           wireguard_interface: wg0
           cni_version: v1.3.0
           has_ufw: true
+          # 4 vCPU / 8Gi: light reservation
+          kubelet_kube_reserved: "cpu=250m,memory=512Mi"
+          kubelet_system_reserved: "cpu=250m,memory=512Mi"
+          kubelet_eviction_hard: "memory.available<300Mi,nodefs.available<10%,imagefs.available<15%"
 
         s2204:
           ansible_host: s2204
@@ -34,6 +42,10 @@ all:
           wireguard_interface: wg0
           cni_version: v1.3.0
           has_ufw: true
+          # 20 vCPU / 32Gi: reservation already applied on this node
+          kubelet_kube_reserved: "cpu=500m,memory=1Gi"
+          kubelet_system_reserved: "cpu=500m,memory=1Gi"
+          kubelet_eviction_hard: "memory.available<500Mi,nodefs.available<10%,imagefs.available<15%"
 
         k8s-proxy:
           ansible_host: prox
@@ -44,12 +56,24 @@ all:
           wireguard_interface: wg0
           cni_version: v1.3.0
           has_ufw: true
+          # 2 vCPU / 12Gi: memory-only reservation (avoid reserving scarce CPU)
+          kubelet_kube_reserved: "memory=512Mi"
+          kubelet_system_reserved: "memory=512Mi"
+          kubelet_eviction_hard: "memory.available<500Mi,nodefs.available<10%,imagefs.available<15%"
 
   vars:
     # Kubernetes configuration
     kubernetes_version: "1.34.3-1.1"
     pod_network_cidr: "10.244.0.0/16"
     service_cidr: "10.96.0.0/12"
+
+    # kubelet resource reservations (defaults: none; override per host above).
+    # Empty string => the corresponding kubelet flag is omitted.
+    # NOTE: --eviction-hard, when set, replaces ALL eviction thresholds, so the
+    # per-host string keeps the nodefs/imagefs defaults (10%/15%) alongside memory.
+    kubelet_kube_reserved: ""
+    kubelet_system_reserved: ""
+    kubelet_eviction_hard: ""
 
     # WireGuard network
     wireguard_network: "10.130.5.0/24"

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -81,11 +81,18 @@
     - kubeadm
     - kubectl
 
-- name: Configure kubelet node IP
+- name: Configure kubelet extra args (node IP + resource reservations)
   ansible.builtin.lineinfile:
     path: /etc/default/kubelet
     regexp: "^KUBELET_EXTRA_ARGS="
-    line: 'KUBELET_EXTRA_ARGS="--node-ip={{ wireguard_ip }}"'
+    line: >-
+      KUBELET_EXTRA_ARGS="{{
+        (['--node-ip=' + wireguard_ip]
+          + (['--kube-reserved=' + kubelet_kube_reserved] if (kubelet_kube_reserved | default('')) else [])
+          + (['--system-reserved=' + kubelet_system_reserved] if (kubelet_system_reserved | default('')) else [])
+          + (['--eviction-hard=' + kubelet_eviction_hard] if (kubelet_eviction_hard | default('')) else [])
+        ) | join(' ')
+      }}"
     mode: "0644"
     owner: root
     group: root


### PR DESCRIPTION
## Summary

Reflect into the repo the kubelet resource reservations applied manually on **s2204 (shion-ubuntu-2505)**, made **configurable per host** since the cluster hardware is heterogeneous.

s2204's live `/var/lib/kubelet/config.yaml` carried (local to that node only — not in the cluster-wide `kubelet-config` ConfigMap):
```yaml
kubeReserved:   {cpu: 500m, memory: 1Gi}
systemReserved: {cpu: 500m, memory: 1Gi}
evictionHard:   {memory.available: 500Mi, nodefs.available: 10%, imagefs.available: 15%}
```

## Why per-node values

Applying s2204's reservation (1 CPU + 2Gi total) verbatim everywhere would halve schedulable CPU on the 2-vCPU nodes:

| Node | CPU | Mem | Reservation chosen |
|------|-----|-----|--------------------|
| instance-2024-1 (control plane) | 2 | 12Gi | memory-only (512Mi + 512Mi), **no CPU** |
| instance-k8s-proxy | 2 | 12Gi | memory-only (512Mi + 512Mi), **no CPU** |
| shion-raspi-cm4 | 4 | 8Gi | cpu=250m, memory=512Mi each |
| shion-ubuntu-2505 (s2204) | 20 | 32Gi | cpu=500m, memory=1Gi each (matches current) |

## Changes

- **`inventory.yml`** — `kubelet_kube_reserved` / `kubelet_system_reserved` / `kubelet_eviction_hard` per host, empty defaults in `all.vars` (empty ⇒ flag omitted).
- **`roles/kubernetes/tasks/main.yml`** — assemble `KUBELET_EXTRA_ARGS` from `--node-ip` plus the reservation flags, dropping any flag whose value is empty.

CLI flags override `/var/lib/kubelet/config.yaml` and survive kubeadm regeneration.

## Verification

- [x] `just lint` passes (production, 0 failures)
- [x] `ansible-playbook --syntax-check` passes
- [x] Rendered `KUBELET_EXTRA_ARGS` confirmed per host via local-connection dry render (nodes untouched), e.g. s2204:
  `--node-ip=10.130.5.4 --kube-reserved=cpu=500m,memory=1Gi --system-reserved=cpu=500m,memory=1Gi --eviction-hard=memory.available<500Mi,nodefs.available<10%,imagefs.available<15%`
- [ ] `just deploy` to apply (restarts kubelet; allocatable shrinks slightly on newly-reserved nodes)

> Note: the empty-default keeps behavior unchanged for any host without overrides.