### PR TITLE
📝 Fix stale 10.0.0.0/24 overlay refs in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ To keep sensitive host information (like public IPs) private and out of version 
 **Example: k8s-proxy host**
 
 - Stored in inventory.yml with `ansible_host: prox` (hostname, not IP)
-- Uses internal WireGuard IP: 10.0.0.21
+- Uses internal WireGuard IP: 10.130.5.21
 - Public IP is kept private and not committed to git
 - Deploys like any other worker node: `just deploy =k8s-proxy`
 
@@ -133,7 +133,7 @@ To keep sensitive host information (like public IPs) private and out of version 
 ### WireGuard
 
 - **Template**: `roles/wireguard/templates/wg0.conf.j2`
-- Overlay network: 10.0.0.0/24
+- Overlay network: 10.130.5.0/24
 - Private keys generated locally on each node (never transmitted)
 - Worker nodes configured with 25-second persistent keepalive
 - Control plane acts as WireGuard endpoint


### PR DESCRIPTION
## Summary

While auditing the cluster for leftovers from the old `10.0.0.0/24` WireGuard overlay (now `10.130.5.0/24`), two stale references remained in `CLAUDE.md`:

- `Uses internal WireGuard IP: 10.0.0.21` → `10.130.5.21` (k8s-proxy)
- `Overlay network: 10.0.0.0/24` → `10.130.5.0/24`

The inventory and templates already use `10.130.5.0/24`; this just aligns the docs.

## Related live-node cleanup (already applied, not part of this PR)

The same audit found and fixed two stale `10.0.0.x` remnants directly on the nodes (operational, not repo):
- Control plane `wg0.conf`: removed a redundant `Mac M4 Max → 10.0.0.129/32` peer (same pubkey as the active `mac-m4-max → 10.130.5.129/32`; dead at runtime). Applied via `wg syncconf` (no tunnel restart).
- s2204 `kubeadm-flags.env`: removed a stale `--node-ip=10.0.0.4` (effective node-ip was already `10.130.5.4` via `/etc/default/kubelet`).

## Verification

- [x] `grep -rn '10\.0\.0\.'` across the repo returns nothing
- [x] All 4 nodes Ready after the live cleanups; mac peer connected via 10.130.5.129; s2204 node-ip = 10.130.5.4