### PR TITLE
✨ Run apt periodic timers hourly on all nodes

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Reload systemd and restart apt timers
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: restarted
+    daemon_reload: true
+  loop:
+    - apt-daily.timer
+    - apt-daily-upgrade.timer

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -169,3 +169,37 @@
     path: "/tmp/cni-plugins-{{ common_arch_effective }}-{{ cni_version }}.tgz"
     state: absent
   when: not common_cni_installed_ok
+
+# -------------------------------------------------------------------
+# apt periodic timers: run list refresh + unattended upgrades hourly
+# instead of the daily vendor default (override the systemd timers).
+# -------------------------------------------------------------------
+- name: Ensure apt periodic timer override directories exist
+  ansible.builtin.file:
+    path: "/etc/systemd/system/{{ item }}.timer.d"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  loop:
+    - apt-daily
+    - apt-daily-upgrade
+  when: ansible_os_family == "Debian"
+
+- name: Set apt periodic timers to run hourly
+  ansible.builtin.copy:
+    dest: "/etc/systemd/system/{{ item }}.timer.d/override.conf"
+    # Empty OnCalendar= clears the list-valued vendor default before setting hourly.
+    content: |
+      [Timer]
+      OnCalendar=
+      OnCalendar=hourly
+      RandomizedDelaySec=5m
+    owner: root
+    group: root
+    mode: "0644"
+  loop:
+    - apt-daily
+    - apt-daily-upgrade
+  when: ansible_os_family == "Debian"
+  notify: Reload systemd and restart apt timers


### PR DESCRIPTION
## Summary

Codify, on the Ansible side, the systemd timer override that makes apt run **hourly** instead of the daily vendor default — applied to the whole fleet. This was set manually on the Oracle nodes (k8s, k8s-proxy); this PR makes it idempotent and fleet-wide.

Equivalent to:
```ini
# /etc/systemd/system/{apt-daily,apt-daily-upgrade}.timer.d/override.conf
[Timer]
OnCalendar=
OnCalendar=hourly
RandomizedDelaySec=5m
```

## Changes

- **`roles/common/tasks/main.yml`** — ensure the two `*.timer.d` override directories exist and write `override.conf` (empty `OnCalendar=` clears the list-valued vendor default before setting `hourly`). Guarded on `ansible_os_family == "Debian"`.
- **`roles/common/handlers/main.yml`** (new) — on change, `daemon-reload` + restart `apt-daily.timer` and `apt-daily-upgrade.timer`.

## Idempotency / blast radius

Verified with `--check`: the rendered `content` is **byte-identical** to the existing override on k8s and k8s-proxy → those nodes are a no-op. On next deploy, **cm4 and s2204** get the override created and the timers restarted.

## Note

apt-daily-upgrade runs unattended-upgrades hourly. By default unattended-upgrades only pulls from the security origins, so the Kubernetes/containerd packages (from pkgs.k8s.io etc., not in the default allowed origins) are not auto-upgraded — the cluster components won't be bumped unexpectedly by this change.

## Test plan

- [x] `just lint` passes (production, 0 failures)
- [x] `ansible-playbook --syntax-check` passes
- [x] `--check` confirms no-op on k8s / k8s-proxy (content matches live)
- [ ] `just deploy` to roll out to cm4 / s2204