### PR TITLE
⬆️ Bump Kubernetes to 1.35.5; derive apt channel from version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Control Plane (k8s):** Oracle Cloud instance in Tokyo (ARM64)
 - **Worker Nodes:** Raspberry Pi CM4 (ARM64) and Ubuntu x86_64 VM
 
-**Core Technologies:** Ansible 2.19.0, Kubernetes 1.34.3, containerd 1.7.27, WireGuard, Cilium CNI
+**Core Technologies:** Ansible 2.19.0, Kubernetes 1.35.5, containerd 1.7.27, WireGuard, Cilium CNI
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ ansible-playbook -i inventory.yml site.yml --limit=cm4
 
 ```yaml
 # In inventory.yml
-kubernetes_version: "1.34.3-1.1"  # Update version
+kubernetes_version: "1.35.5-1.1"  # Update version (apt channel is derived from this)
 ```
 
 ### Modify Network CIDRs

--- a/inventory.yml
+++ b/inventory.yml
@@ -63,7 +63,10 @@ all:
 
   vars:
     # Kubernetes configuration
-    kubernetes_version: "1.34.3-1.1"
+    kubernetes_version: "1.35.5-1.1"
+    # apt repo channel (minor) derived from kubernetes_version, e.g. "v1.35".
+    # Bumping kubernetes_version is enough; the channel follows automatically.
+    kubernetes_apt_channel: "v{{ kubernetes_version.split('.')[0] }}.{{ kubernetes_version.split('.')[1] }}"
     pod_network_cidr: "10.244.0.0/16"
     service_cidr: "10.96.0.0/12"
 

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Download Kubernetes APT repository signing key
   ansible.builtin.get_url:
-    url: https://pkgs.k8s.io/core:/stable:/v1.34/deb/Release.key
+    url: "https://pkgs.k8s.io/core:/stable:/{{ kubernetes_apt_channel }}/deb/Release.key"
     dest: /etc/apt/keyrings/kubernetes-apt-keyring-armored.key
     mode: "0644"
 
@@ -25,7 +25,7 @@
 
 - name: Add Kubernetes APT repository with signed-by
   ansible.builtin.apt_repository:
-    repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.34/deb/ /"
+    repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{ kubernetes_apt_channel }}/deb/ /"
     filename: kubernetes
     state: present
     update_cache: true

--- a/site.yml
+++ b/site.yml
@@ -8,13 +8,25 @@
   gather_facts: true
 
   pre_tasks:
-    - name: Remove legacy Kubernetes APT sources to prevent Signed-By conflicts
+    # The canonical Kubernetes APT source is /etc/apt/sources.list.d/kubernetes.list
+    # (managed by the kubernetes role via `filename: kubernetes`). Remove any
+    # stray version-named or backup files so they can't pin an old channel or
+    # cause Signed-By conflicts. Version-agnostic: no per-upgrade maintenance.
+    - name: Find stray legacy Kubernetes APT source files
+      ansible.builtin.find:
+        paths: /etc/apt/sources.list.d
+        patterns:
+          - "pkgs_k8s_io_core_stable_v1_*_deb.list"
+          - "kubernetes.list.*"
+      register: stray_k8s_sources
+
+    - name: Remove stray legacy Kubernetes APT sources (keep canonical kubernetes.list)
       ansible.builtin.file:
-        path: "{{ item }}"
+        path: "{{ item.path }}"
         state: absent
-      loop:
-        - /etc/apt/sources.list.d/pkgs_k8s_io_core_stable_v1_33_deb.list
-        - /etc/apt/sources.list.d/pkgs_k8s_io_core_stable_v1_34_deb.list
+      loop: "{{ stray_k8s_sources.files }}"
+      loop_control:
+        label: "{{ item.path }}"
 
     - name: Update apt cache (Debian/Ubuntu)
       ansible.builtin.apt:


### PR DESCRIPTION
## Summary

The cluster was upgraded out-of-band to **v1.35.5** (all 4 nodes; apt channel switched to v1.35). This reconciles the repo with reality and removes the version-duplication that let the repo drift behind the cluster.

## Changes

- **`inventory.yml`** — `kubernetes_version` `1.34.3-1.1` → `1.35.5-1.1`, and add a derived `kubernetes_apt_channel` (`v{major}.{minor}`). Future minor bumps are now a **single var change**.
- **`roles/kubernetes/tasks/main.yml`** — the Release.key URL and the apt repo line now use `{{ kubernetes_apt_channel }}` instead of a hardcoded `v1.34` in two places (the source of the drift).
- **`site.yml`** — replace the hardcoded legacy-source removal (`pkgs_k8s_io_core_stable_v1_33/34_deb.list`) with a **version-agnostic** `find` of stray `pkgs_k8s_io_core_stable_v1_*_deb.list` and `kubernetes.list.*` backups. Canonical source stays `/etc/apt/sources.list.d/kubernetes.list` (managed via `filename: kubernetes`). No per-upgrade maintenance.
- **`README.md` / `CLAUDE.md`** — version references → 1.35.5.

## Why the cleanup change

Audit of the live nodes:
- k8s / k8s-proxy / cm4: single `kubernetes.list` @ v1.35 ✅
- s2204: also has a stale `kubernetes.list.distUpgrade` @ v1.34 (inert — apt ignores non-`.list` — but cruft). The new generic cleanup removes it on next deploy.
- The old `pkgs_k8s_io_core_stable_v1_*` files no longer exist on any node (the hardcoded removal was already a no-op).

## Verification

- [x] `kubernetes_apt_channel` renders to `v1.35` (local debug) → URL `…/stable:/v1.35/deb/`, byte-matching the live `kubernetes.list` on all nodes
- [x] No `1.34` / `v1_33` / `v1_34` references remain in the repo
- [x] `just lint` passes (production, 0 failures); `--syntax-check` passes
- [x] `just deploy` — expected no-op for the apt source (already v1.35); removes s2204's `.distUpgrade` stray

## Note

This only records the 1.35 state. Going to 1.36 later is a separate minor hop (and Cilium 1.16.5 ↔ 1.36 compatibility should be confirmed first).