### PR TITLE
✨ Adopt zone-based WireGuard addressing plan with CI enforcement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,20 +96,45 @@ control_plane:  # k8s node
     k8s:
       ansible_host: k8s.shion1305.com
       wireguard_ip: 10.130.5.1
+      wireguard_zone: oci          # required; IP must fall in the zone's CIDR
       # ... other vars
 
 workers:  # cm4, s2204, and secret hosts
   hosts:
     cm4:
       ansible_host: cm4
-      wireguard_ip: 10.130.5.3
+      wireguard_ip: 10.130.5.65
+      wireguard_zone: home-static
     s2204:
       ansible_host: s2204
-      wireguard_ip: 10.130.5.4
+      wireguard_ip: 10.130.5.66
+      wireguard_zone: home-static
     k8s-proxy:
       ansible_host: prox
-      wireguard_ip: 10.130.5.21
+      wireguard_ip: 10.130.5.2
+      wireguard_zone: oci
 ```
+
+### WireGuard addressing plan (zones)
+
+The overlay `10.130.5.0/24` is partitioned into role/location zones, defined once
+in `inventory.yml` under `wireguard_zones`:
+
+- `oci` → `10.130.5.0/29` — cloud nodes (control plane, k8s-proxy)
+- `home-static` → `10.130.5.64/27` — always-on home machines (k8s workers)
+- `owned-mobile` → `10.130.5.96/28` — my own roaming devices
+- `external-static` → `10.130.5.128/28` — other people's always-on hosts
+- `external-mobile` → `10.130.5.144/28` — other people's roaming devices
+
+Every host and static peer **must** declare a `wireguard_zone` (hosts) / `zone`
+(static peers), and the assigned IP must fall inside that zone's CIDR.
+`tests/test_inventory_zones.py` (run by `just test` in CI) fails on a missing
+attribute, a zone/IP mismatch, an out-of-overlay IP, a duplicate IP, or
+overlapping zones. The control plane keeps `10.130.5.1` — never renumber it
+(it is baked into the cluster PKI / etcd / `apiserver_advertise_address`).
+
+Full reference (current allocation, reserved blocks, how to add a host/peer,
+renumbering caveats): **`docs/WIREGUARD_ADDRESSING.md`**.
 
 ### Secret Hosts
 
@@ -124,7 +149,7 @@ To keep sensitive host information (like public IPs) private and out of version 
 **Example: k8s-proxy host**
 
 - Stored in inventory.yml with `ansible_host: prox` (hostname, not IP)
-- Uses internal WireGuard IP: 10.130.5.21
+- Uses internal WireGuard IP: 10.130.5.2 (zone `oci`)
 - Public IP is kept private and not committed to git
 - Deploys like any other worker node: `just deploy =k8s-proxy`
 

--- a/README.md
+++ b/README.md
@@ -235,11 +235,25 @@ service_cidr: "10.96.0.0/12"         # Service network
 wireguard_network: "10.130.5.0/24"     # WireGuard network
 ```
 
+### WireGuard Addressing (Zones)
+
+The overlay `10.130.5.0/24` is split into role/location **zones** (`oci`,
+`home-static`, `owned-mobile`, `external-static`, `external-mobile`). Every host
+and static peer declares a `wireguard_zone` / `zone`, and CI fails if the
+assigned IP doesn't fall inside that zone's CIDR. This keeps home vs cloud (and
+owned vs external) distinguishable by IP and addressable as a CIDR.
+
+See **[docs/WIREGUARD_ADDRESSING.md](docs/WIREGUARD_ADDRESSING.md)** for the full
+plan, current allocation, and how to pick an IP/zone for a new node.
+
 ### Add Additional Nodes
 
-1. Add node to `inventory.yml` under appropriate group
-2. Configure SSH access
-3. Run playbook: `ansible-playbook -i inventory.yml site.yml --limit=new_node`
+1. Pick a zone and a free IP inside its CIDR (see the addressing plan above)
+2. Add the node to `inventory.yml` under the appropriate group, with both
+   `wireguard_ip` and `wireguard_zone`
+3. Configure SSH access
+4. Validate: `just lint && just test` (the zone test checks IP/zone consistency)
+5. Run playbook: `ansible-playbook -i inventory.yml site.yml --limit=new_node`
 
 ## Monitoring and Maintenance
 

--- a/docs/WIREGUARD_ADDRESSING.md
+++ b/docs/WIREGUARD_ADDRESSING.md
@@ -1,0 +1,109 @@
+# WireGuard Overlay Addressing Plan (Zones)
+
+The WireGuard overlay `10.130.5.0/24` is partitioned into role/location **zones**.
+Every host and static peer is assigned an IP from exactly one zone and **must
+declare which zone it belongs to**. CI verifies that the declared zone and the
+assigned IP agree, so the plan can't silently drift.
+
+This keeps the topology self-documenting (you can tell what a node is from its
+IP), lets firewall/policy rules target a whole class of nodes as a single CIDR,
+and reserves room to grow each class without renumbering.
+
+## Zones
+
+Defined once in `inventory.yml` under `wireguard_zones`:
+
+| Zone | CIDR | Range | Purpose |
+|---|---|---|---|
+| `oci` | `10.130.5.0/29` | `.1`–`.6` | Cloud nodes (Oracle Cloud) |
+| `home-static` | `10.130.5.64/27` | `.65`–`.95` | Always-on home machines (k8s workers) |
+| `owned-mobile` | `10.130.5.96/28` | `.97`–`.111` | My own roaming devices (laptops/phones) |
+| `external-static` | `10.130.5.128/28` | `.129`–`.143` | Other people's always-on hosts |
+| `external-mobile` | `10.130.5.144/28` | `.145`–`.159` | Other people's roaming devices |
+
+Unassigned blocks, reserved for future growth: `.8/29`, `.16/28`, `.32/27`,
+`.112/28`, `.160/27`, `.192/26`.
+
+## Current allocation
+
+| Name | Zone | IP | Managed by |
+|---|---|---|---|
+| `k8s` (control plane) | `oci` | `10.130.5.1` | Ansible |
+| `k8s-proxy` | `oci` | `10.130.5.2` | Ansible |
+| `cm4` | `home-static` | `10.130.5.65` | Ansible |
+| `s2204` | `home-static` | `10.130.5.66` | Ansible |
+| `mac-m4-max` | `owned-mobile` | `10.130.5.97` | external device |
+| `tomoya-mac` | `external-mobile` | `10.130.5.145` | external device |
+
+`external-static` currently has no members (reserved).
+
+## Rules (enforced by CI)
+
+`tests/test_inventory_zones.py` runs in CI via `just test`. It parses
+`inventory.yml` (no live hosts) and **fails** when:
+
+1. a host or static peer is **missing** its `wireguard_zone` (hosts) / `zone`
+   (static peers) attribute;
+2. the **zone derived from the IP** (the zone whose CIDR contains it) does not
+   equal the **declared** zone — i.e. a typo in either field;
+3. an IP falls **outside** the overlay (`wireguard_network`);
+4. two entries share the **same IP**;
+5. two zone CIDRs **overlap**, or a zone is not inside the overlay.
+
+So the declared zone is a redundant, human-readable assertion that CI keeps
+honest against the actual IP.
+
+## Adding a cluster node (Ansible-managed)
+
+1. Pick the right zone (`home-static` for a home box, `oci` for a cloud box).
+2. Pick a free IP inside that zone's CIDR (see the range column above).
+3. Add the host under the right group in `inventory.yml` with both
+   `wireguard_ip` and `wireguard_zone`:
+   ```yaml
+   newbox:
+     ansible_host: newbox
+     wireguard_ip: 10.130.5.67
+     wireguard_zone: home-static
+     # ...
+   ```
+4. `just lint && just test` — the zone test confirms the IP/zone are consistent.
+5. Deploy with `just deploy` (run in a maintenance window for renumbers, since a
+   worker's WireGuard IP is its kubelet `--node-ip`; see the caveats below).
+
+## Adding a static peer (external device)
+
+1. Generate the device's WireGuard key; set the device's own `Address` to the
+   chosen overlay IP.
+2. Add it under `wireguard_static_peers` in `inventory.yml`:
+   ```yaml
+   wireguard_static_peers:
+     my-phone:
+       public_key: "<device public key>"
+       allowed_ips: "10.130.5.98/32"
+       zone: owned-mobile
+   ```
+3. `just lint && just test`, then deploy (control plane picks up the new peer).
+
+## Renumbering caveats
+
+- **Never renumber the control plane (`10.130.5.1`).** It is baked into the
+  cluster PKI (API server cert SANs), etcd, and `apiserver_advertise_address`;
+  changing it effectively means rebuilding the cluster.
+- **Cluster workers**: the WireGuard IP is the kubelet `--node-ip`. Changing it
+  changes the node's InternalIP — kubelet restarts, Cilium re-establishes the
+  tunnel, brief cross-node blip (pod IPs are unaffected). Do it in a maintenance
+  window and deploy all affected nodes together.
+- **Static peers are not managed by this repo.** Renumbering one here only
+  updates the control-plane-side `allowed_ips`; the device's own `Address` must
+  be changed to match at the same time, or that peer drops until it is.
+- **Removing a static peer**: the control plane's incremental merge preserves
+  peers already present in the running config, so deleting one from
+  `inventory.yml` will not remove it from the live control plane. Remove it
+  there explicitly (`sudo wg set wg0 peer <pubkey> remove` and drop it from
+  `/etc/wireguard/wg0.conf`) or regenerate the config from scratch.
+
+## See also
+
+- `CLAUDE.md` → *WireGuard addressing plan (zones)*
+- `docs/WIREGUARD_INCREMENTAL_UPDATES.md` — how control-plane peers are merged
+- `tests/test_inventory_zones.py` — the CI guard described above

--- a/inventory.yml
+++ b/inventory.yml
@@ -8,6 +8,7 @@ all:
           ansible_user: ubuntu
           ansible_ssh_private_key_file: ~/.ssh/credentials/shion1305-oci
           wireguard_ip: 10.130.5.1
+          wireguard_zone: oci
           architecture: arm64
           wireguard_interface: wg0
           wireguard_port: 51820
@@ -23,7 +24,8 @@ all:
           ansible_host: cm4
           ansible_user: shion
           ansible_ssh_private_key_file: ~/.ssh/credentials/rasp-cm4
-          wireguard_ip: 10.130.5.3
+          wireguard_ip: 10.130.5.65
+          wireguard_zone: home-static
           architecture: arm64
           wireguard_interface: wg0
           cni_version: v1.3.0
@@ -37,7 +39,8 @@ all:
           ansible_host: s2204
           ansible_user: shion
           ansible_ssh_private_key_file: ~/.ssh/credentials/shion1305
-          wireguard_ip: 10.130.5.4
+          wireguard_ip: 10.130.5.66
+          wireguard_zone: home-static
           architecture: amd64
           wireguard_interface: wg0
           cni_version: v1.3.0
@@ -51,7 +54,8 @@ all:
           ansible_host: prox
           ansible_user: ubuntu
           ansible_ssh_private_key_file: ~/.ssh/credentials/shion1305-oci
-          wireguard_ip: 10.130.5.21
+          wireguard_ip: 10.130.5.2
+          wireguard_zone: oci
           architecture: arm64
           wireguard_interface: wg0
           cni_version: v1.3.0
@@ -81,23 +85,33 @@ all:
     # WireGuard network
     wireguard_network: "10.130.5.0/24"
 
-    # Static WireGuard peers (non-Kubernetes nodes)
+    # WireGuard overlay addressing plan. Every host and static peer MUST declare a
+    # `wireguard_zone`; the IP it is assigned MUST fall inside that zone's CIDR.
+    # CI (tests/test_inventory_zones.py) enforces this and fails on a missing
+    # attribute, a zone/IP mismatch, an out-of-overlay IP, or a duplicate IP.
+    # Unassigned blocks (room to grow): .8/29, .16/28, .32/27, .112/28,
+    # .160/27, .192/26.
+    wireguard_zones:
+      oci: "10.130.5.0/29"               # cloud nodes (control plane, k8s-proxy)
+      home-static: "10.130.5.64/27"      # always-on home machines (k8s workers)
+      owned-mobile: "10.130.5.96/28"     # my own roaming devices (laptops/phones)
+      external-static: "10.130.5.128/28" # other people's always-on hosts
+      external-mobile: "10.130.5.144/28" # other people's roaming devices
+
+    # Static WireGuard peers (non-Kubernetes nodes).
+    # `zone` is required and its CIDR must contain `allowed_ips` (CI-enforced).
+    # NOTE: renumbering a static peer also requires updating that device's own
+    # wg config `Address` to match -- they are not managed by this repo.
     wireguard_static_peers:
       mac-m4-max:
         public_key: "nP4kEiL1SQHb3emQlqit43UzroOYa+PZGtsBxJQbaFM="
-        allowed_ips: "10.130.5.129/32"
+        allowed_ips: "10.130.5.97/32"
+        zone: owned-mobile
 
       tomoya-mac:
         public_key: "+6KaWGZ4ePBZPhQJhGrMK4qU837OzXvNe86nntx1kno="
-        allowed_ips: "10.130.5.130/32"
-
-      yhost1:
-        public_key: "MkLMc9uNqgOyRIoL+H4GnRjSaZdqb2n8Pu4OAv7oB24="
-        allowed_ips: "10.130.5.193/32"
-
-      yhost2:
-        public_key: "tNeoX+ZsCphucM6C37KaclacOJTRCy90021+yPHlR0E="
-        allowed_ips: "10.130.5.194/32"
+        allowed_ips: "10.130.5.145/32"
+        zone: external-mobile
 
     # Control plane endpoint
     control_plane_endpoint: "k8s.shion1305.com:6443"

--- a/tests/test_inventory_zones.py
+++ b/tests/test_inventory_zones.py
@@ -1,0 +1,110 @@
+"""Enforce the WireGuard overlay addressing plan declared in inventory.yml.
+
+Every host and static peer must declare a `wireguard_zone` / `zone`, and the IP
+it is assigned must fall inside that zone's CIDR (`wireguard_zones`). The zone is
+also auto-derived from the IP, so a typo in either field is caught as a mismatch.
+
+CI runs this via `just test` (pytest). It parses the YAML directly — no Ansible
+or live hosts involved.
+"""
+
+import ipaddress
+from pathlib import Path
+
+import pytest
+import yaml
+
+INVENTORY = Path(__file__).parent.parent / "inventory.yml"
+
+
+def _load():
+    return yaml.safe_load(INVENTORY.read_text())
+
+
+def _vars():
+    return _load()["all"]["vars"]
+
+
+def _zone_networks():
+    return {z: ipaddress.ip_network(c) for z, c in _vars()["wireguard_zones"].items()}
+
+
+def _entries():
+    """Yield (name, ip, declared_zone) for every host and static peer."""
+    inv = _load()
+    out = []
+    for group in inv["all"]["children"].values():
+        for host, hv in (group.get("hosts") or {}).items():
+            out.append((host, hv.get("wireguard_ip"), hv.get("wireguard_zone")))
+    for peer, pv in (_vars().get("wireguard_static_peers") or {}).items():
+        ip = (pv.get("allowed_ips") or "").split("/")[0] or None
+        out.append((peer, ip, pv.get("zone")))
+    return out
+
+
+ENTRIES = _entries()
+ENTRY_IDS = [e[0] for e in ENTRIES]
+
+
+def _auto_zone(ip):
+    """The single zone whose CIDR contains ip, or None."""
+    addr = ipaddress.ip_address(ip)
+    hits = [z for z, net in _zone_networks().items() if addr in net]
+    return hits[0] if len(hits) == 1 else None
+
+
+def test_at_least_one_entry():
+    assert ENTRIES, "no hosts or static peers found in inventory.yml"
+
+
+@pytest.mark.parametrize("name,ip,zone", ENTRIES, ids=ENTRY_IDS)
+def test_entry_has_ip_and_zone(name, ip, zone):
+    assert ip, f"{name}: missing WireGuard IP"
+    assert zone, f"{name}: missing required `wireguard_zone`/`zone` attribute"
+
+
+@pytest.mark.parametrize("name,ip,zone", ENTRIES, ids=ENTRY_IDS)
+def test_zone_name_is_defined(name, ip, zone):
+    zones = _zone_networks()
+    assert zone in zones, (
+        f"{name}: zone '{zone}' is not defined in wireguard_zones "
+        f"(known: {sorted(zones)})"
+    )
+
+
+@pytest.mark.parametrize("name,ip,zone", ENTRIES, ids=ENTRY_IDS)
+def test_ip_within_overlay(name, ip, zone):
+    overlay = ipaddress.ip_network(_vars()["wireguard_network"])
+    assert ipaddress.ip_address(ip) in overlay, f"{name}: {ip} is outside {overlay}"
+
+
+@pytest.mark.parametrize("name,ip,zone", ENTRIES, ids=ENTRY_IDS)
+def test_declared_zone_matches_ip(name, ip, zone):
+    """The declared zone must equal the zone auto-derived from the IP."""
+    derived = _auto_zone(ip)
+    assert derived == zone, (
+        f"{name}: IP {ip} is in zone '{derived}' but is declared as '{zone}'. "
+        f"Fix the IP or the wireguard_zone so they agree."
+    )
+
+
+def test_no_duplicate_ips():
+    seen = {}
+    for name, ip, _ in ENTRIES:
+        assert ip not in seen, f"duplicate IP {ip}: {seen.get(ip)} and {name}"
+        seen[ip] = name
+
+
+def test_zones_do_not_overlap_and_fit_overlay():
+    overlay = ipaddress.ip_network(_vars()["wireguard_network"])
+    nets = list(_zone_networks().items())
+    for z, net in nets:
+        assert net.subnet_of(overlay), f"zone {z} ({net}) is not within {overlay}"
+    for i in range(len(nets)):
+        for j in range(i + 1, len(nets)):
+            (za, na), (zb, nb) = nets[i], nets[j]
+            assert not na.overlaps(nb), f"zones overlap: {za} ({na}) and {zb} ({nb})"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## TL;DR

An **addressing-only change**: partition the overlay `10.130.5.0/24` into role/location **zones**, renumber nodes/peers into them, and add a **CI guard** that fails if any IP and its declared zone disagree. No behavioural or feature change.

Independent of #48 (direct same-site peering). See *Relationship to #48* below.

## Addressing plan

Defined once in `inventory.yml` under `wireguard_zones`:

| Zone | CIDR | Members |
|---|---|---|
| `oci` | `10.130.5.0/29` | cloud nodes (control plane, k8s-proxy) |
| `home-static` | `10.130.5.64/27` | always-on home machines (k8s workers) |
| `owned-mobile` | `10.130.5.96/28` | my own roaming devices |
| `external-static` | `10.130.5.128/28` | other people's always-on hosts (reserved) |
| `external-mobile` | `10.130.5.144/28` | other people's roaming devices |

Unassigned (room to grow): `.8/29`, `.16/28`, `.32/27`, `.112/28`, `.160/27`, `.192/26`.

## Renumbering

| Host / peer | Zone | Old | New |
|---|---|---|---|
| k8s (control plane) | `oci` | `.1` | **`.1` (kept)** |
| k8s-proxy | `oci` | `.21` | **`.2`** |
| cm4 | `home-static` | `.3` | **`.65`** |
| s2204 | `home-static` | `.4` | **`.66`** |
| mac-m4-max | `owned-mobile` | `.129` | **`.97`** |
| tomoya-mac | `external-mobile` | `.130` | **`.145`** |
| yhost1 / yhost2 | — | `.193` / `.194` | **removed** |

**The control plane keeps `10.130.5.1`** — it is baked into the cluster PKI (API server cert SANs), etcd, and `apiserver_advertise_address`; renumbering it would mean rebuilding the cluster.

## CI enforcement

Each host declares `wireguard_zone`; each static peer declares `zone`. Both are **required**. `tests/test_inventory_zones.py` (run by `just test`) parses the inventory and **fails** on:

- a missing `wireguard_zone` / `zone` attribute,
- a **zone/IP mismatch** — the zone auto-derived from the IP's CIDR ≠ the declared zone,
- an IP outside the overlay,
- a duplicate IP,
- overlapping zone CIDRs.

## ⚠️ Rollout caveats (this touches live node identity)

1. **Cluster nodes are Ansible-managed** (cm4, s2204, k8s-proxy). A worker's WireGuard IP is its kubelet `--node-ip`, so renumbering changes the node's InternalIP → kubelet restart, Cilium re-establishes the tunnel, brief cross-node blip (pod IPs unaffected). Do it in a maintenance window with `just deploy` (all hosts).
2. **Static peers are external devices** (macs) and are **not** managed by this repo. This PR only changes the control-plane-side `allowed_ips`; each device's own wg `Address` must be updated to the new IP at the same time, or that peer drops until it is.
3. **Removing yhost1/yhost2**: the control plane's incremental merge preserves peers already in the running config, so deleting them here will not remove them from the live control plane — drop them there explicitly (`sudo wg set wg0 peer <pubkey> remove`).

## Relationship to #48

#48 (direct same-site peering) is a separate feature PR. This PR is the foundational addressing change and is independent. **Recommended order: merge this PR first, then rebase #48** onto the renumbered `main` (its `wireguard_direct_peer_group` additions sit cleanly on top of the new IPs/zones).

## Verification (offline, not applied to live hosts)

| Check | Result |
|---|---|
| `just test` (zone validation + existing template tests) | ✅ passed |
| `just lint` (ansible-lint, production) | ✅ 0 failures |
| `ansible-inventory --host` (IP + zone resolution) | ✅ k8s .1/oci, k8s-proxy .2/oci, cm4 .65/home-static, s2204 .66/home-static |

## Changed files

- `inventory.yml` — `wireguard_zones`; renumber hosts + static peers; required `wireguard_zone`/`zone`; drop yhost1/yhost2
- `tests/test_inventory_zones.py` — **new** CI guard for zone/IP consistency
- `docs/WIREGUARD_ADDRESSING.md` — **new** full addressing reference
- `CLAUDE.md`, `README.md` — document the zones and the guard

