### PR TITLE
✨ Onboard s2605 as a home-static worker

### DIFF
--- a/inventory.yml
+++ b/inventory.yml
@@ -154,6 +154,11 @@ all:
         allowed_ips: "10.130.5.145/32"
         zone: external-mobile
 
+      oki-mac:
+        public_key: "tO8SOnoDpqWL/JMjanivoP4hb101MGYBJ7FXeqTaIhk="
+        allowed_ips: "10.130.5.146/32"
+        zone: external-mobile
+
     # Control plane endpoint
     control_plane_endpoint: "k8s.shion1305.com:6443"
     apiserver_advertise_address: "10.130.5.1"

--- a/inventory.yml
+++ b/inventory.yml
@@ -63,6 +63,25 @@ all:
           kubelet_system_reserved: "cpu=500m,memory=1Gi"
           kubelet_eviction_hard: "memory.available<500Mi,nodefs.available<10%,imagefs.available<15%"
 
+        s2605:
+          ansible_host: s2605
+          ansible_user: shion1305
+          ansible_ssh_private_key_file: ~/.ssh/credentials/shion1305
+          wireguard_ip: 10.130.5.67
+          wireguard_zone: home-static
+          architecture: amd64
+          wireguard_interface: wg0
+          cni_version: v1.3.0
+          has_ufw: true
+          # Same home LAN as cm4/s2204 -> they peer directly (see cm4 for details).
+          wireguard_direct_peer_group: home
+          # s2605's address on the shared home LAN (direct-tunnel endpoint).
+          wireguard_lan_endpoint: "192.168.40.35"
+          # 24 vCPU / 60Gi: light reservation
+          kubelet_kube_reserved: "cpu=500m,memory=1Gi"
+          kubelet_system_reserved: "cpu=500m,memory=1Gi"
+          kubelet_eviction_hard: "memory.available<500Mi,nodefs.available<10%,imagefs.available<15%"
+
         k8s-proxy:
           ansible_host: prox
           ansible_user: ubuntu

--- a/inventory.yml
+++ b/inventory.yml
@@ -149,6 +149,11 @@ all:
         allowed_ips: "10.130.5.97/32"
         zone: owned-mobile
 
+      iphone-17-pro:
+        public_key: "Jq57VYd5Lb2Tijsq37P3prARi0wHgAEtlZ9Nh7nsTQ0="
+        allowed_ips: "10.130.5.98/32"
+        zone: owned-mobile
+
       tomoya-mac:
         public_key: "+6KaWGZ4ePBZPhQJhGrMK4qU837OzXvNe86nntx1kno="
         allowed_ips: "10.130.5.145/32"
@@ -157,6 +162,11 @@ all:
       oki-mac:
         public_key: "tO8SOnoDpqWL/JMjanivoP4hb101MGYBJ7FXeqTaIhk="
         allowed_ips: "10.130.5.146/32"
+        zone: external-mobile
+
+      shun-mac:
+        public_key: "3t3rclENLeKHoWgq70X6mbhzfYd+8Xnn/epBWkPchFs="
+        allowed_ips: "10.130.5.147/32"
         zone: external-mobile
 
     # Control plane endpoint


### PR DESCRIPTION
Adds **s2605** (Ubuntu 24.04, amd64, 24 vCPU / 60 GiB) on the shared home LAN as a Kubernetes worker in the `home-static` zone, joined to the `home` direct-peer mesh with cm4/s2204.

## Inventory change
| field | value |
|---|---|
| `wireguard_ip` | `10.130.5.67` (next free in `home-static` `10.130.5.64/27`) |
| `wireguard_zone` | `home-static` |
| `wireguard_direct_peer_group` | `home` (same LAN as cm4/s2204) |
| `wireguard_lan_endpoint` | `192.168.40.35` |
| `architecture` | `amd64` |
| kubelet reservations | `cpu=500m,memory=1Gi` kube + system (24 vCPU / 60 GiB) |

## Validation (offline)
- `just test` → 69 passed (zone checks: `.67` ∈ `home-static`, no duplicate/overlap)
- `just lint` → production, 0 failures / 45 files

## Deploy + live verification
Deployed `site.yml --limit k8s,cm4,s2204,s2605` (the whole `home` mesh redeploys together because workers regenerate their WireGuard key each run). Previewed with `-e wireguard_dry_run=true` first.

- **5/5 nodes Ready**; `shion-ubuntu-2605` InternalIP `10.130.5.67`
- **WireGuard mesh up**: s2605 handshakes directly with cm4 (`192.168.40.34`) and s2204 (`192.168.40.32`) over the LAN, plus the control-plane hub
- **Cilium**: agent Running on s2605; `CiliumNode` registered at `10.130.5.67`
- **Cross-node pod traffic**: busybox s2605 ↔ cm4 both directions, 0% packet loss (~7ms, LAN-direct, not the ~16ms hub path)
- Control-plane peer list gained s2605; no existing peers removed