### PR TITLE
✨ Add per-node swap opt-in with a 64Gi managed swapfile on s2605

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,30 @@ workers talk directly, set a shared **`wireguard_direct_peer_group`** on them in
 - **kubeadm init** uses WireGuard IP as advertise address
 - Kubelet configured with node-ip pointing to WireGuard interface
 
+### Node Swap (opt-in, Kubernetes >= 1.35)
+
+Swap is **disabled by default** on every node (classic Kubernetes requirement):
+the `common` role runs `swapoff -a` and strips swap from `/etc/fstab`. Kubernetes
+1.35 ships stable swap support, so a host can opt in **per-node**:
+
+- Set `swap_enabled: true` on the host in `inventory.yml`. `common` then stops
+  disabling swap, and the `kubernetes` role writes a kubelet drop-in
+  (`{{ kubelet_config_dir }}/20-swap.conf`, merged via `kubelet --config-dir`)
+  with `failSwapOn: false` + `memorySwap.swapBehavior` — so kubelet starts with
+  swap on without editing the kubeadm-managed `/var/lib/kubelet/config.yaml`.
+- Add `swap_size` (e.g. `"64G"`, fallocate suffix) to have Ansible allocate,
+  `mkswap`, `fstab`-persist, and `swapon` a managed swapfile at `swap_file`
+  (default `/swapfile`). Leave `swap_size` empty to reuse swap the OS already
+  provides. Creation is idempotent (`creates:` guard); **resizing an existing
+  swapfile is not automated** — `swapoff` + remove it first, then re-deploy.
+- `kubelet_swap_behavior` (default `LimitedSwap`): only **Burstable** pods
+  *without* a memory limit can use swap; Guaranteed/BestEffort pods never do.
+  Use `NoSwap` for a node that tolerates swap but keeps workloads off it.
+- Requires **cgroup v2** (Ubuntu 22.04+ default) — asserted before a swapfile is
+  created. Defaults live in `group_vars/all.yml`; `tests/test_swap_config.py`
+  (run by `just test`) checks the inventory opt-in for consistency.
+- **Current use:** only `s2605` opts in, with a 64Gi managed swapfile.
+
 ### Ansible Configuration (ansible.cfg)
 
 - Host key checking disabled

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -12,6 +12,32 @@
 # across the playbooks and roles as `apt_lock_timeout | default(300)`.
 apt_lock_timeout: 300
 
+# --- Node swap (Kubernetes NodeSwap) -----------------------------------------
+# Classic Kubernetes requires swap OFF, so the default is disabled: the `common`
+# role runs `swapoff -a` and strips swap from /etc/fstab on every host.
+#
+# Kubernetes >= 1.35 ships stable swap support, so a host can opt in per-node by
+# overriding `swap_enabled: true` in inventory.yml. When enabled:
+#   * `common` stops disabling swap; if `swap_size` is non-empty it creates and
+#     activates a managed swapfile of that size (leave empty to use swap the OS
+#     already provides).
+#   * `kubernetes` writes a kubelet drop-in (failSwapOn: false +
+#     memorySwap.swapBehavior) so kubelet starts with swap on and lets eligible
+#     (Burstable, no memory limit) pods use it.
+# Requires cgroup v2 (Ubuntu 22.04+ default) — asserted before a swapfile is made.
+swap_enabled: false
+# Size of the managed swapfile, e.g. "8G" (fallocate suffix: G = GiB). Empty
+# means "do not create/manage a swapfile" — only meaningful when swap_enabled.
+swap_size: ""
+# Path of the managed swapfile.
+swap_file: /swapfile
+# kubelet memorySwap.swapBehavior: LimitedSwap (Burstable pods may use swap) or
+# NoSwap (node tolerates swap but workloads cannot use it).
+kubelet_swap_behavior: LimitedSwap
+# kubelet drop-in config directory (kubelet --config-dir). Matches kubeadm's
+# default so our swap drop-in merges cleanly over the kubeadm-managed config.
+kubelet_config_dir: /etc/kubernetes/kubelet.conf.d
+
 # Firewall allow-rules, consumed by the `firewall` role (roles/firewall). Keeping
 # the Kubernetes port list here removes the hardcoded ports that used to live
 # inline in site.yml's UFW block and makes the policy reviewable in one place.

--- a/inventory.yml
+++ b/inventory.yml
@@ -77,6 +77,11 @@ all:
           kubelet_kube_reserved: "cpu=500m,memory=1Gi"
           kubelet_system_reserved: "cpu=500m,memory=1Gi"
           kubelet_eviction_hard: "memory.available<500Mi,nodefs.available<10%,imagefs.available<15%"
+          # Node swap (Kubernetes NodeSwap, k8s >= 1.35). This node keeps swap on
+          # and kubelet may schedule swap onto eligible pods; Ansible provisions a
+          # 64Gi managed swapfile. Only host opted in — see group_vars/all.yml.
+          swap_enabled: true
+          swap_size: "64G"
 
         raspi5:
           ansible_host: raspi5

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -13,26 +13,10 @@
     lock_timeout: "{{ apt_lock_timeout | default(300) }}"
 
 # -----------------------------
-# Swap: disable only if enabled
+# Swap (disable by default; opt-in per host — see swap.yml / group_vars/all.yml)
 # -----------------------------
-- name: Check if any swap is active
-  ansible.builtin.command: swapon --summary
-  register: common_swapon_summary
-  changed_when: false
-
-- name: Disable swap for Kubernetes when enabled
-  ansible.builtin.command: swapoff -a
-  when: common_swapon_summary.stdout | trim != ""
-  # `swapon --summary` should be empty if no swap is active.
-  changed_when: true
-
-- name: Remove any swap entries from fstab
-  # This is idempotent, if no swap entries exist, nothing changes.
-  ansible.builtin.lineinfile:
-    path: /etc/fstab
-    regexp: '^\s*[^#]+\s+none\s+swap\s+'
-    state: absent # Removes swap entries
-  # This will be marked as changed only when files changed by this task.
+- name: Configure node swap
+  ansible.builtin.include_tasks: swap.yml
 
 - name: Load kernel modules
   # This is idempotent, loading an already loaded module has no effect.

--- a/roles/common/tasks/swap.yml
+++ b/roles/common/tasks/swap.yml
@@ -1,0 +1,94 @@
+---
+# Node swap handling.
+#
+# Default (`swap_enabled: false`): enforce the classic Kubernetes requirement and
+# disable swap everywhere.
+# Opt-in (`swap_enabled: true`, Kubernetes >= 1.35): keep swap on and, when
+# `swap_size` is set, provision a managed swapfile. The matching kubelet drop-in
+# (failSwapOn / memorySwap.swapBehavior) is written by the `kubernetes` role.
+# See group_vars/all.yml for the variable contract.
+
+- name: Check if any swap is active
+  ansible.builtin.command: swapon --summary
+  register: common_swapon_summary
+  changed_when: false
+
+# --- swap_enabled: false (default) -> disable swap ---------------------------
+- name: Disable swap for Kubernetes when enabled
+  ansible.builtin.command: swapoff -a
+  when:
+    - not (swap_enabled | default(false) | bool)
+    - common_swapon_summary.stdout | trim != ""
+  # `swapon --summary` is empty when no swap is active, so this only runs (and
+  # only reports changed) when there is actually swap to turn off.
+  changed_when: true
+
+- name: Remove any swap entries from fstab
+  # Idempotent: with no swap entries nothing changes. Skipped when swap is opted
+  # in so a managed swapfile's fstab entry (added below) is not stripped again.
+  ansible.builtin.lineinfile:
+    path: /etc/fstab
+    regexp: '^\s*[^#]+\s+none\s+swap\s+'
+    state: absent
+  when: not (swap_enabled | default(false) | bool)
+
+# --- swap_enabled: true with swap_size -> ensure a managed swapfile ----------
+- name: Provision managed swapfile
+  when:
+    - swap_enabled | default(false) | bool
+    - (swap_size | default('')) | length > 0
+  block:
+    # Kubernetes swap support requires cgroup v2. Fail early with a clear message
+    # instead of letting kubelet misbehave. /sys/fs/cgroup/cgroup.controllers only
+    # exists under the unified (v2) hierarchy.
+    - name: Assert cgroup v2 is active (required for Kubernetes swap)
+      ansible.builtin.stat:
+        path: /sys/fs/cgroup/cgroup.controllers
+      register: common_cgroup_v2
+
+    - name: Fail when cgroup v2 is not active
+      ansible.builtin.fail:
+        msg: >-
+          swap_enabled requires the cgroup v2 unified hierarchy, but
+          /sys/fs/cgroup/cgroup.controllers is missing on {{ inventory_hostname }}.
+          Boot with systemd.unified_cgroup_hierarchy=1 (Ubuntu 22.04+ default).
+      when: not common_cgroup_v2.stat.exists
+
+    - name: Allocate swapfile
+      ansible.builtin.command:
+        cmd: "fallocate -l {{ swap_size }} {{ swap_file }}"
+        creates: "{{ swap_file }}"
+      register: common_swapfile_alloc
+
+    - name: Secure swapfile permissions
+      ansible.builtin.file:
+        path: "{{ swap_file }}"
+        owner: root
+        group: root
+        mode: "0600"
+
+    # mkswap must run in-line right after allocation (before the swapon below),
+    # not deferred to a handler; guarded so it only formats a freshly created
+    # file, never an already-active swapfile.
+    - name: Format swapfile # noqa: no-handler
+      ansible.builtin.command:
+        cmd: "mkswap {{ swap_file }}"
+      when: common_swapfile_alloc is changed
+      changed_when: true
+
+    - name: Persist swapfile in fstab
+      ansible.builtin.lineinfile:
+        path: /etc/fstab
+        regexp: "^{{ swap_file | regex_escape }}\\s"
+        line: "{{ swap_file }} none swap sw 0 0"
+        state: present
+
+    - name: Gather active swap devices
+      ansible.builtin.command: swapon --show=NAME --noheadings
+      register: common_active_swaps
+      changed_when: false
+
+    - name: Activate swapfile
+      ansible.builtin.command: "swapon {{ swap_file }}"
+      when: swap_file not in common_active_swaps.stdout_lines
+      changed_when: true

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -107,12 +107,46 @@
           + (['--kube-reserved=' + kubelet_kube_reserved] if (kubelet_kube_reserved | default('')) else [])
           + (['--system-reserved=' + kubelet_system_reserved] if (kubelet_system_reserved | default('')) else [])
           + (['--eviction-hard=' + kubelet_eviction_hard] if (kubelet_eviction_hard | default('')) else [])
+          + (['--config-dir=' + kubelet_config_dir] if (swap_enabled | default(false) | bool) else [])
         ) | join(' ')
       }}"
     mode: "0644"
     owner: root
     group: root
     create: true
+  notify: Restart kubelet
+
+# Kubernetes swap (>= 1.35): failSwapOn / memorySwap.swapBehavior can only be set
+# via KubeletConfiguration, not a CLI flag. Drop a merge file into --config-dir so
+# it layers over the kubeadm-managed /var/lib/kubelet/config.yaml without editing
+# it. The `common` role is what actually keeps swap on / provisions the swapfile.
+- name: Ensure kubelet drop-in config directory exists
+  ansible.builtin.file:
+    path: "{{ kubelet_config_dir }}"
+    state: directory
+    mode: "0755"
+  when: swap_enabled | default(false) | bool
+
+- name: Configure kubelet swap behavior (drop-in KubeletConfiguration)
+  ansible.builtin.copy:
+    dest: "{{ kubelet_config_dir }}/20-swap.conf"
+    mode: "0644"
+    owner: root
+    group: root
+    content: |
+      apiVersion: kubelet.config.k8s.io/v1beta1
+      kind: KubeletConfiguration
+      failSwapOn: false
+      memorySwap:
+        swapBehavior: {{ kubelet_swap_behavior }}
+  when: swap_enabled | default(false) | bool
+  notify: Restart kubelet
+
+- name: Remove kubelet swap drop-in when swap is disabled
+  ansible.builtin.file:
+    path: "{{ kubelet_config_dir }}/20-swap.conf"
+    state: absent
+  when: not (swap_enabled | default(false) | bool)
   notify: Restart kubelet
 
 - name: Enable and start services

--- a/tests/test_swap_config.py
+++ b/tests/test_swap_config.py
@@ -1,0 +1,111 @@
+"""Validate the per-node swap opt-in declared in inventory.yml.
+
+Kubernetes >= 1.35 supports swap, so a host can keep swap on by setting
+`swap_enabled: true` (and, to have Ansible provision a swapfile, `swap_size`).
+Defaults live in group_vars/all.yml; per-host overrides in inventory.yml.
+
+This guards against the easy misconfigurations:
+  * `swap_size` set without `swap_enabled` (silently ignored -> no swapfile),
+  * a malformed `swap_size` (fallocate would fail mid-deploy),
+  * an invalid `kubelet_swap_behavior`,
+  * accidentally flipping swap on for a host that should not have it.
+
+CI runs this via `just test` (pytest). It parses the YAML directly — no Ansible
+or live hosts involved.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).parent.parent
+INVENTORY = ROOT / "inventory.yml"
+GROUP_VARS = ROOT / "group_vars" / "all.yml"
+
+# Hosts expected to run with swap on. Update this set (deliberately) whenever you
+# opt another node in — the test then re-checks its size/behavior too.
+EXPECTED_SWAP_HOSTS = {"s2605"}
+
+# fallocate size, e.g. "64G", "8192M", "2G" (suffix = powers of 1024).
+SIZE_RE = re.compile(r"^\d+(\.\d+)?[KMGTP]?B?$")
+VALID_BEHAVIORS = {"LimitedSwap", "NoSwap"}
+
+
+def _defaults():
+    return yaml.safe_load(GROUP_VARS.read_text())
+
+
+def _hosts():
+    """Yield (name, hostvars) for every inventory host."""
+    inv = yaml.safe_load(INVENTORY.read_text())
+    out = []
+    for group in inv["all"]["children"].values():
+        for host, hv in (group.get("hosts") or {}).items():
+            out.append((host, hv or {}))
+    return out
+
+
+DEFAULTS = _defaults()
+HOSTS = _hosts()
+HOST_IDS = [h[0] for h in HOSTS]
+
+
+def _effective(hostvars, key):
+    """Host override if present, else the group_vars/all.yml default."""
+    return hostvars.get(key, DEFAULTS.get(key))
+
+
+def test_swap_defaults_are_conservative():
+    """The cluster-wide default must keep swap disabled."""
+    assert DEFAULTS.get("swap_enabled") is False, (
+        "group_vars/all.yml must default swap_enabled to false"
+    )
+    assert DEFAULTS.get("swap_size", "") == "", (
+        "group_vars/all.yml must default swap_size to empty"
+    )
+    assert DEFAULTS.get("kubelet_swap_behavior") in VALID_BEHAVIORS
+
+
+@pytest.mark.parametrize("name,hv", HOSTS, ids=HOST_IDS)
+def test_swap_size_implies_enabled(name, hv):
+    """A swap_size with swap_enabled off would be silently ignored."""
+    size = _effective(hv, "swap_size") or ""
+    enabled = bool(_effective(hv, "swap_enabled"))
+    if size:
+        assert enabled, (
+            f"{name}: swap_size='{size}' set but swap_enabled is false "
+            f"(swapfile would never be created)"
+        )
+
+
+@pytest.mark.parametrize("name,hv", HOSTS, ids=HOST_IDS)
+def test_swap_size_is_well_formed(name, hv):
+    size = _effective(hv, "swap_size") or ""
+    if size:
+        assert SIZE_RE.match(size), (
+            f"{name}: swap_size='{size}' is not a valid fallocate size"
+        )
+
+
+@pytest.mark.parametrize("name,hv", HOSTS, ids=HOST_IDS)
+def test_swap_behavior_is_valid(name, hv):
+    behavior = _effective(hv, "kubelet_swap_behavior")
+    assert behavior in VALID_BEHAVIORS, (
+        f"{name}: kubelet_swap_behavior='{behavior}' must be one of {VALID_BEHAVIORS}"
+    )
+
+
+def test_only_expected_hosts_enable_swap():
+    enabled = {name for name, hv in HOSTS if bool(_effective(hv, "swap_enabled"))}
+    assert enabled == EXPECTED_SWAP_HOSTS, (
+        f"swap-enabled hosts {enabled} != expected {EXPECTED_SWAP_HOSTS}; "
+        f"update EXPECTED_SWAP_HOSTS if this change is intentional"
+    )
+
+
+def test_s2605_has_64g_swap():
+    hv = dict(HOSTS)["s2605"]
+    assert bool(_effective(hv, "swap_enabled")) is True
+    assert _effective(hv, "swap_size") == "64G"


### PR DESCRIPTION
## What

Kubernetes 1.35 ships **stable swap support**, so this adds the ability to enable swap **per node** instead of always disabling it. Only `s2605` opts in for now, with a 64Gi managed swapfile.

## Why

The cluster used to run `swapoff -a` on every host (classic pre-1.35 requirement). With swap now stable in kubelet, memory-heavy nodes can benefit from swap without breaking the others.

## How it works

- **Default unchanged** — every host still disables swap unless it opts in (`swap_enabled: true`).
- `common` role (`roles/common/tasks/swap.yml`): when enabled and `swap_size` is set, it provisions an idempotent managed swapfile — cgroup v2 assert → `fallocate` → `chmod 0600` → `mkswap` → `fstab` → `swapon`.
- `kubernetes` role: when enabled, adds `kubelet --config-dir` and drops in a `KubeletConfiguration` (`failSwapOn: false` + `memorySwap.swapBehavior`) that **merges over** the kubeadm-managed `/var/lib/kubelet/config.yaml` — no editing of the kubeadm file.
- Defaults live in `group_vars/all.yml`; per-host opt-in in `inventory.yml`.

## s2605

```yaml
swap_enabled: true
swap_size: "64G"    # fallocate G = GiB
```

`LimitedSwap` (default) means only **Burstable pods without a memory limit** may use swap.

## Tests

- New `tests/test_swap_config.py` validates the inventory opt-in: `swap_size` implies `swap_enabled`, size format, valid `kubelet_swap_behavior`, and an "only s2605 enabled" guard.
- `just test` → 102 passed · `just lint` (ansible-lint, production profile) → clean · `site.yml --syntax-check` → OK.

## Operational notes

- Requires **cgroup v2** (Ubuntu 22.04+ default) — asserted before swapfile creation.
- **Resizing** an existing swapfile is not automated (`creates:` guard). To resize: `swapoff` + remove, then re-deploy.
- Apply with `just deploy s2605`; kubelet restarts automatically via handler.